### PR TITLE
Fix race in rosbaz View

### DIFF
--- a/.github/workflows/catkin-build.yml
+++ b/.github/workflows/catkin-build.yml
@@ -26,6 +26,8 @@ jobs:
         path: 'azure-storage-cpplite'
 
     - name: 'build azure-storage-cpplite'
+      env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       run: |
         set -ex
         sudo apt-get update -qq

--- a/include/rosbaz/view.h
+++ b/include/rosbaz/view.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <set>
 
-#include <boost/optional.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 #include <ros/time.h>
 #include <rosbag/query.h>
@@ -48,10 +48,10 @@ public:
   class iterator : public boost::iterator_facade<iterator, MessageInstance, boost::forward_traversal_tag>
   {
   public:
-    iterator() = default;
+    iterator();
     iterator(iterator const& i);
     iterator& operator=(iterator const& i);
-    ~iterator() = default;
+    ~iterator();
 
   private:
     friend struct View;
@@ -73,7 +73,7 @@ public:
     std::vector<ViewIterHelper> iters_{};
     uint32_t view_revision_;
 
-    mutable boost::optional<MessageInstance> message_instance_{};
+    mutable std::unique_ptr<MessageInstance> message_instance_{};
   };
 
   explicit View(const Bag& bag, const ros::Time& start_time = ros::TIME_MIN, const ros::Time& end_time = ros::TIME_MAX);
@@ -118,5 +118,8 @@ private:
 
   uint32_t m_size_cache{ 0 };
   uint32_t m_size_revision{ 0 };
+
+  MessageInstance* newMessageInstance(const rosbag::ConnectionInfo& connection_info, rosbag::IndexEntry const& index,
+                                      Bag const& bag) const;
 };
 }  // namespace rosbaz

--- a/src/bag.cpp
+++ b/src/bag.cpp
@@ -191,7 +191,14 @@ void Bag::parseIndexSection(std::mutex& sync, rosbaz::bag_parsing::ChunkExt& chu
         ROS_DEBUG_STREAM("chunk_pos: " << chunk_ext.chunk_info.pos << " conn: " << connection_id
                                        << " offset: " << index_entry.offset);
 
-        connection_index.insert(connection_index.end(), index_entry);
+        // we can't use connection_index.end() because many chunks are parsed in parallel. since we have a lock, its
+        // fine to find the first connection index whose chunk pos is larger then the current one - or .end().
+        auto insert_at = std::lower_bound(connection_index.begin(), connection_index.end(), index_entry.chunk_pos,
+                                          [](const rosbag::IndexEntry& other_index_entry, const uint64_t value) {
+                                            return other_index_entry.chunk_pos < value;
+                                          });
+
+        connection_index.insert(insert_at, index_entry);
         offsets.push_back(index_entry.offset);
       }
     }


### PR DESCRIPTION
Since `parseIndexSection` runs on several threads, the chunks are not necessarily processed in order which may lead to connection indices whose chunk pos are not sequentially ordered.

Since connection indices are stored in a linked list and changes are done using a lock, instead of simply appending chunk indices to the end of the list we add it to where it belongs.