### PR TITLE
Add index entries to multiset connection_indexes_ in linear fashion

### DIFF
--- a/include/rosbaz/bag.h
+++ b/include/rosbaz/bag.h
@@ -55,10 +55,10 @@ private:
   void parseFileTail(rosbaz::DataSpan bag_tail);
 
   /// Parses the index records contained in \p chunk_index following a chunk record described by \p chunk_ext. This
-  /// populates \p connection_indexes_ and also sets \p message_records of the given \p chunk_ext.
+  /// populates \p index_entries and \p message_records of the given \p chunk_ext.
   ///
   /// The implementation has to be thread safe since it may be invoked simultaneously for multiple chunks.
-  void parseIndexSection(std::mutex& sync, rosbaz::bag_parsing::ChunkExt& chunk_ext, rosbaz::DataSpan chunk_index,
+  void parseIndexSection(rosbaz::bag_parsing::ChunkExt& chunk_ext, rosbaz::DataSpan chunk_index,
                          const uint64_t index_offset);
 
   /// Reads the chunk header for the given \p chunk_info, extracts the position of and reads the index sections which

--- a/include/rosbaz/bag_parsing/chunk_ext.h
+++ b/include/rosbaz/bag_parsing/chunk_ext.h
@@ -10,13 +10,25 @@ namespace rosbaz
 {
 namespace bag_parsing
 {
+struct IndexEntryExt
+{
+  IndexEntryExt(uint32_t _connection_id, const rosbag::IndexEntry& _index_entry)
+    : connection_id{ _connection_id }, index_entry{ _index_entry }
+  {
+  }
+
+  uint32_t connection_id;
+  rosbag::IndexEntry index_entry;
+};
+
 /// Provides extended information for a given chunk (see
 /// http://wiki.ros.org/Bags/Format/2.0).
 ///
 /// In addition to the rosbag::ChunkInfo describing the offset of the given
 /// chunk in the bag file, we provide offset and size of the data section of the
 /// chunk, offset and size of the index section following the chunk, as well as
-/// offsets and sizes of all message records within the data section.
+/// offsets and sizes of all message records within the data section together with all
+/// index entries of the chunks.
 struct ChunkExt
 {
   ChunkExt(const rosbag::ChunkInfo& _chunk_info, const rosbag::ChunkHeader& _chunk_header, std::uint64_t _data_offset,
@@ -39,6 +51,8 @@ struct ChunkExt
   std::uint32_t index_size{ 0 };
 
   std::vector<MessageRecordInfo> message_records{};
+
+  std::vector<IndexEntryExt> index_entries{};
 };
 }  // namespace bag_parsing
 }  // namespace rosbaz

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>rosbaz</name>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <description>Streaming rosbags from azure blob storage</description>
 
   <maintainer email="jan@bernloehrs.de">Jan Bernloehr</maintainer>


### PR DESCRIPTION
...  to avoid seek and shuffeling of data when accessed from multiple threads

On a bag with 300k index entries this reduces index parsing from 4mins to 1s which is then on-par with rosbag's initial implementation.

fyi: @betwo
