### PR TITLE
Harmonize with rosbag and fix add query

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 option(REGRESSION_TESTS "Build and execute regression tests" OFF)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(ROSBAZ_CXX_FLAGS
   -Wall
   -Wextra
@@ -95,27 +95,34 @@ if (CATKIN_ENABLE_TESTING)
 
   if (REGRESSION_TESTS)
     include(ExternalProject)
-    ExternalProject_Add(bag-file
-      URL               https://storage.googleapis.com/cartographer-public-data/bags/backpack_2d/b0-2014-07-11-10-58-16.bag
-      URL_HASH          MD5=7ed841ca72cb82adcf4a3fc6b85cac5a
-      DOWNLOAD_NO_EXTRACT TRUE
-      CONFIGURE_COMMAND ""
-      INSTALL_COMMAND   ""
-      DOWNLOAD_DIR      ${CMAKE_CURRENT_BINARY_DIR}
-      BUILD_COMMAND     rosbag decompress ${CMAKE_CURRENT_BINARY_DIR}/b0-2014-07-11-10-58-16.bag
-    )
+
+    set(bag_files "b0-2014-07-11-10-58-16" "b0-2014-07-21-12-42-53")
+    set(bag_hashes "7ed841ca72cb82adcf4a3fc6b85cac5a" "fb3b78206276c4f871bd7ac00437f7ca")
+
+    foreach(bag_file IN ZIP_LISTS bag_files bag_hashes)
+      ExternalProject_Add(bag-file-${bag_file_0}
+        URL               "https://storage.googleapis.com/cartographer-public-data/bags/backpack_2d/${bag_file_0}.bag"
+        URL_HASH          "MD5=${bag_file_1}"
+        DOWNLOAD_NO_EXTRACT TRUE
+        CONFIGURE_COMMAND ""
+        INSTALL_COMMAND   ""
+        DOWNLOAD_DIR      ${CMAKE_CURRENT_BINARY_DIR}
+        BUILD_COMMAND     ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/${bag_file_0}.bag ${CMAKE_CURRENT_BINARY_DIR}/${bag_file_0}-decompressed.bag && ${CMAKE_COMMAND} -E rm -f ${CMAKE_CURRENT_BINARY_DIR}/${bag_file_0}-decompressed.orig.bag && rosbag decompress ${CMAKE_CURRENT_BINARY_DIR}/${bag_file_0}-decompressed.bag
+      )
+      list(APPEND bag-file-targets bag-file-${bag_file_0})
+    endforeach()
 
     file(GLOB _regression_test_sources CONFIGURE_DEPENDS "regression_test/test_*.cpp")
     catkin_add_gtest(regression_test_${PROJECT_NAME} ${_regression_test_sources})
     target_link_libraries(regression_test_${PROJECT_NAME} ${PROJECT_NAME} ${catkin_LIBRARIES} gtest_main)
 
-    add_dependencies(regression_test_${PROJECT_NAME} bag-file)
+    add_dependencies(regression_test_${PROJECT_NAME} ${bag-file-targets})
 
     find_package(benchmark QUIET)
     if (benchmark_FOUND)
       add_executable(regression_test_benchmark regression_test/benchmark.cpp)
       target_link_libraries(regression_test_benchmark PRIVATE ${PROJECT_NAME} ${catkin_LIBRARIES} benchmark::benchmark)
-      add_dependencies(regression_test_benchmark bag-file)
+      add_dependencies(regression_test_benchmark ${bag-file-targets})
     endif()
   endif()
 endif()

--- a/include/rosbaz/bag.h
+++ b/include/rosbaz/bag.h
@@ -93,6 +93,7 @@ private:
   std::vector<rosbag::ChunkInfo> chunks_{};
   // extended chunk info needed for rosbaz
   std::vector<rosbaz::bag_parsing::ChunkExt> chunk_exts_{};
+  std::unordered_map<uint64_t, const rosbaz::bag_parsing::ChunkExt*> chunk_exts_lookup_{};
 
   bool chunk_indices_parsed_ = false;
 

--- a/include/rosbaz/bag.h
+++ b/include/rosbaz/bag.h
@@ -68,13 +68,15 @@ private:
   void parseChunkInfo(std::mutex& sync, rosbaz::io::IReader& reader, const rosbag::ChunkInfo& chunk_info,
                       uint64_t next_chunk_pos);
 
-  /// Fills \p connection_indexes_ and \p chunks_.
+  /// Fills \p connection_indexes_ and \p chunk_exts_.
   ///
   /// The implementation may read data for the present chunks simultaneously.
   void parseChunkIndices(rosbaz::io::IReader& reader);
 
   mutable std::shared_ptr<rosbaz::io::IReader> reader_{};
 
+  // rosbag uses a map<uint32_t, ConnectionInfo*>. Since only parseFileTail can modify connections_
+  // it is safe to store the ConnectionInfo in the map. Only expansion would invalidate the addresses.
   std::unordered_map<uint32_t, rosbag::ConnectionInfo> connections_{};
 
   std::uint32_t bag_revision_{ 0 };
@@ -87,11 +89,14 @@ private:
 
   std::uint64_t file_size_{ 0 };
 
-  std::vector<rosbag::ChunkInfo> chunk_infos_{};
+  // plain rosbag chunk infos
+  std::vector<rosbag::ChunkInfo> chunks_{};
+  // extended chunk info needed for rosbaz
+  std::vector<rosbaz::bag_parsing::ChunkExt> chunk_exts_{};
 
   bool chunk_indices_parsed_ = false;
 
+  // rosbag uses a map. Since there are as many indices as chunk infos, it is safe to reserve once.
   std::unordered_map<uint32_t, std::multiset<rosbag::IndexEntry>> connection_indexes_{};
-  std::vector<rosbaz::bag_parsing::ChunkExt> chunks_{};
 };
 }  // namespace rosbaz

--- a/include/rosbaz/bag_parsing/chunk_ext.h
+++ b/include/rosbaz/bag_parsing/chunk_ext.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <cstdint>
+#include <unordered_map>
+#include <vector>
 
 #include <rosbag/structures.h>
 
@@ -50,7 +52,7 @@ struct ChunkExt
   std::uint64_t index_offset{ 0 };  // absolute
   std::uint32_t index_size{ 0 };
 
-  std::vector<MessageRecordInfo> message_records{};
+  std::unordered_map<uint64_t, MessageRecordInfo> message_records{};
 
   std::vector<IndexEntryExt> index_entries{};
 };

--- a/include/rosbaz/bag_parsing/header.h
+++ b/include/rosbaz/bag_parsing/header.h
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <string>
 #include <sstream>
-#include <unordered_map>
+#include <map>
 
 #include "rosbaz/common.h"
 #include "rosbaz/exceptions.h"
@@ -18,7 +18,8 @@ namespace bag_parsing
 struct Header
 {
   std::uint8_t op{ 0 };
-  std::unordered_map<std::string, rosbaz::DataSpan> fields{};
+  // in this scenario, a map is faster than an unordered map
+  std::map<std::string, rosbaz::DataSpan> fields{};
 
   template <class T>
   T read_field_little_endian(const std::string& field_name) const

--- a/include/rosbaz/query.h
+++ b/include/rosbaz/query.h
@@ -11,9 +11,34 @@ struct BagQuery
 {
   BagQuery(const Bag& _bag, const rosbag::Query& _query, uint32_t _bag_revision);
 
-  std::reference_wrapper<const Bag> bag;
+  const Bag* bag;
   rosbag::Query query;
   uint32_t bag_revision;
+};
+
+struct MessageRange
+{
+  MessageRange(std::multiset<rosbag::IndexEntry>::const_iterator _begin,
+               std::multiset<rosbag::IndexEntry>::const_iterator _end, const rosbag::ConnectionInfo& _connection_info,
+               const BagQuery& _bag_query);
+
+  std::multiset<rosbag::IndexEntry>::const_iterator begin;
+  std::multiset<rosbag::IndexEntry>::const_iterator end;
+  const rosbag::ConnectionInfo* connection_info;
+  const BagQuery* bag_query{ nullptr };
+};
+
+struct ViewIterHelper
+{
+  ViewIterHelper(std::multiset<rosbag::IndexEntry>::const_iterator _iter, const MessageRange& _range);
+
+  std::multiset<rosbag::IndexEntry>::const_iterator iter;
+  const MessageRange* range;
+};
+
+struct ViewIterHelperCompare
+{
+  bool operator()(ViewIterHelper const& a, ViewIterHelper const& b);
 };
 
 }  // namespace rosbaz

--- a/include/rosbaz/view.h
+++ b/include/rosbaz/view.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <memory>
 #include <set>
+#include <vector>
 
 #include <boost/iterator/iterator_facade.hpp>
 #include <ros/time.h>
@@ -17,34 +18,15 @@ namespace rosbaz
 {
 struct View;
 
-struct MessageRange
-{
-  MessageRange(std::multiset<rosbag::IndexEntry>::const_iterator _begin,
-               std::multiset<rosbag::IndexEntry>::const_iterator _end, const rosbag::ConnectionInfo& _connection_info,
-               const BagQuery& _bag_query);
-
-  std::multiset<rosbag::IndexEntry>::const_iterator begin;
-  std::multiset<rosbag::IndexEntry>::const_iterator end;
-  const rosbag::ConnectionInfo* connection_info;
-  const BagQuery* bag_query{ nullptr };
-};
-
-struct ViewIterHelper
-{
-  ViewIterHelper(std::multiset<rosbag::IndexEntry>::const_iterator _iter, const MessageRange& _range);
-
-  std::multiset<rosbag::IndexEntry>::const_iterator iter;
-  const MessageRange* range;
-};
-
-struct ViewIterHelperCompare
-{
-  bool operator()(ViewIterHelper const& a, ViewIterHelper const& b);
-};
-
 struct View
 {
 public:
+  /// An iterator that points to a MessageInstance from a bag
+  ///
+  /// This iterator stores the MessageInstance that it is returning a
+  /// reference to.  If you increment the iterator, that
+  /// MessageInstance is destroyed.  You should never store the
+  /// pointer to this reference.
   class iterator : public boost::iterator_facade<iterator, MessageInstance, boost::forward_traversal_tag>
   {
   public:
@@ -76,10 +58,28 @@ public:
     mutable std::unique_ptr<MessageInstance> message_instance_{};
   };
 
+  using const_iterator = iterator;
+
+  /// Create a view on a bag
+  ///
+  /// \param[in] bag             The bag file on which to run this query
+  /// \param[in] start_time      The beginning of the time range for the query
+  /// \param[in] end_time        The end of the time range for the query
   explicit View(const Bag& bag, const ros::Time& start_time = ros::TIME_MIN, const ros::Time& end_time = ros::TIME_MAX);
 
+  /// Create a view on a bag
+  ///
+  /// \param[in] bag             The bag file on which to run this query
+  /// \param[in] query           The actual query to evaluate which connections to include
+  /// \param[in] start_time      The beginning of the time range for the query
+  /// \param[in] end_time        The end of the time range for the query
   explicit View(const Bag& bag, std::function<bool(rosbag::ConnectionInfo const*)> query,
                 const ros::Time& start_time = ros::TIME_MIN, const ros::Time& end_time = ros::TIME_MAX);
+
+  View(const View& view) = delete;
+  View& operator=(const View& view) = delete;
+
+  ~View();
 
   size_t size();
 
@@ -111,13 +111,12 @@ private:
   void updateQueries(BagQuery& q);
   void update();
 
-  std::vector<MessageRange> m_ranges{};
+  std::vector<std::unique_ptr<MessageRange>> ranges_{};
+  std::vector<std::unique_ptr<BagQuery>> queries_{};
+  uint32_t view_revision_{ 0 };
 
-  std::vector<BagQuery> m_queries{};
-  uint32_t m_view_revision{ 0 };
-
-  uint32_t m_size_cache{ 0 };
-  uint32_t m_size_revision{ 0 };
+  uint32_t size_cache_{ 0 };
+  uint32_t size_revision_{ 0 };
 
   MessageInstance* newMessageInstance(const rosbag::ConnectionInfo& connection_info, rosbag::IndexEntry const& index,
                                       Bag const& bag) const;

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>rosbaz</name>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
   <description>Streaming rosbags from azure blob storage</description>
 
   <maintainer email="jan@bernloehrs.de">Jan Bernloehr</maintainer>

--- a/regression_test/benchmark.cpp
+++ b/regression_test/benchmark.cpp
@@ -28,21 +28,21 @@ void runBenchmark(benchmark::State& state, const BagT& bag, const std::string& t
 
 static void BM_rosbag_chatty(benchmark::State& state)
 {
-  rosbag::Bag bag{ "b0-2014-07-11-10-58-16.bag" };
+  rosbag::Bag bag{ "b0-2014-07-11-10-58-16-decompressed.bag" };
   runBenchmark<rosbag::View, sensor_msgs::Imu>(state, bag, "imu");
 }
 BENCHMARK(BM_rosbag_chatty);
 
 static void BM_rosbaz_chatty(benchmark::State& state)
 {
-  rosbaz::Bag bag{ rosbaz::Bag::read(rosbaz::io::StreamReader::open("b0-2014-07-11-10-58-16.bag")) };
+  rosbaz::Bag bag{ rosbaz::Bag::read(rosbaz::io::StreamReader::open("b0-2014-07-11-10-58-16-decompressed.bag")) };
   runBenchmark<rosbaz::View, sensor_msgs::Imu>(state, bag, "imu");
 }
 BENCHMARK(BM_rosbaz_chatty);
 
 static void BM_rosbag_chunky(benchmark::State& state)
 {
-  rosbag::Bag bag{ "b0-2014-07-11-10-58-16.bag" };
+  rosbag::Bag bag{ "b0-2014-07-11-10-58-16-decompressed.bag" };
   runBenchmark<rosbag::View, sensor_msgs::MultiEchoLaserScan>(state, bag,
                                                               "horizontal_"
                                                               "laser_2d");
@@ -51,7 +51,7 @@ BENCHMARK(BM_rosbag_chunky);
 
 static void BM_rosbaz_chunky(benchmark::State& state)
 {
-  rosbaz::Bag bag{ rosbaz::Bag::read(rosbaz::io::StreamReader::open("b0-2014-07-11-10-58-16.bag")) };
+  rosbaz::Bag bag{ rosbaz::Bag::read(rosbaz::io::StreamReader::open("b0-2014-07-11-10-58-16-decompressed.bag")) };
   runBenchmark<rosbaz::View, sensor_msgs::MultiEchoLaserScan>(state, bag,
                                                               "horizontal_"
                                                               "laser_2d");
@@ -62,7 +62,7 @@ static void BM_rosbag_open(benchmark::State& state)
 {
   for (auto _ : state)
   {
-    rosbag::Bag bag{ "b0-2014-07-11-10-58-16.bag" };
+    rosbag::Bag bag{ "b0-2014-07-11-10-58-16-decompressed.bag" };
     benchmark::DoNotOptimize(bag);
     benchmark::ClobberMemory();
   }
@@ -73,7 +73,7 @@ static void BM_rosbaz_open(benchmark::State& state)
 {
   for (auto _ : state)
   {
-    rosbaz::Bag bag{ rosbaz::Bag::read(rosbaz::io::StreamReader::open("b0-2014-07-11-10-58-16.bag")) };
+    rosbaz::Bag bag{ rosbaz::Bag::read(rosbaz::io::StreamReader::open("b0-2014-07-11-10-58-16-decompressed.bag")) };
     benchmark::DoNotOptimize(bag);
     benchmark::ClobberMemory();
   }

--- a/regression_test/test_regression.cpp
+++ b/regression_test/test_regression.cpp
@@ -81,7 +81,8 @@ TEST_P(RegressionTests, equal_messages)
   }
 }
 
-INSTANTIATE_TEST_CASE_P(RegressionTestSuite, RegressionTests, testing::Values("b0-2014-07-11-10-58-16.bag"));
+INSTANTIATE_TEST_CASE_P(RegressionTestSuite, RegressionTests,
+                        testing::Values("b0-2014-07-11-10-58-16-decompressed.bag"));
 
 class TwoFileRegressionTests : public ::testing::TestWithParam<std::tuple<const char*, const char*>>
 {
@@ -105,9 +106,9 @@ TEST_P(TwoFileRegressionTests, two_bags)
   const std::string topic_name = "imu";
 
   rosbaz::View baz_view{ baz0, rosbag::TopicQuery(topic_name) };
-  baz_view.addQuery(baz1, rosbag::TopicQuery(topic_name) );
+  baz_view.addQuery(baz1, rosbag::TopicQuery(topic_name));
   rosbag::View bag_view{ bag0, rosbag::TopicQuery(topic_name) };
-  bag_view.addQuery(bag1, rosbag::TopicQuery(topic_name) );
+  bag_view.addQuery(bag1, rosbag::TopicQuery(topic_name));
 
   ASSERT_EQ(baz_view.size(), bag_view.size());
 
@@ -132,4 +133,6 @@ TEST_P(TwoFileRegressionTests, two_bags)
 }
 
 INSTANTIATE_TEST_CASE_P(TwoFileRegressionTestSuite, TwoFileRegressionTests,
-                        testing::Values(std::make_tuple("b0-2014-07-11-10-58-16.bag", "b0-2014-07-21-12-42-53.bag")));
+                        testing::Values(std::make_tuple("b0-2014-07-11-10-58-16-decompressed.bag", "b0-2014-07-21-12-"
+                                                                                                   "42-53-decompressed."
+                                                                                                   "bag")));

--- a/regression_test/test_regression.cpp
+++ b/regression_test/test_regression.cpp
@@ -82,3 +82,54 @@ TEST_P(RegressionTests, equal_messages)
 }
 
 INSTANTIATE_TEST_CASE_P(RegressionTestSuite, RegressionTests, testing::Values("b0-2014-07-11-10-58-16.bag"));
+
+class TwoFileRegressionTests : public ::testing::TestWithParam<std::tuple<const char*, const char*>>
+{
+public:
+  TwoFileRegressionTests()
+    : baz0{ rosbaz::Bag::read(rosbaz::io::StreamReader::open(std::get<0>(GetParam()))) }
+    , baz1{ rosbaz::Bag::read(rosbaz::io::StreamReader::open(std::get<1>(GetParam()))) }
+    , bag0{ std::get<0>(GetParam()) }
+    , bag1{ std::get<1>(GetParam()) }
+  {
+  }
+
+  rosbaz::Bag baz0;
+  rosbaz::Bag baz1;
+  rosbag::Bag bag0;
+  rosbag::Bag bag1;
+};
+
+TEST_P(TwoFileRegressionTests, two_bags)
+{
+  const std::string topic_name = "imu";
+
+  rosbaz::View baz_view{ baz0, rosbag::TopicQuery(topic_name) };
+  baz_view.addQuery(baz1, rosbag::TopicQuery(topic_name) );
+  rosbag::View bag_view{ bag0, rosbag::TopicQuery(topic_name) };
+  bag_view.addQuery(bag1, rosbag::TopicQuery(topic_name) );
+
+  ASSERT_EQ(baz_view.size(), bag_view.size());
+
+  for (size_t i = 0; i < baz_view.size(); ++i)
+  {
+    auto baz_m = baz_view.begin();
+    std::advance(baz_m, i);
+    auto baz_message = baz_m->instantiate<sensor_msgs::Imu>();
+
+    auto bag_m = bag_view.begin();
+    std::advance(bag_m, i);
+    auto bag_message = bag_m->instantiate<sensor_msgs::Imu>();
+
+    EXPECT_EQ(bag_m->getTime(), baz_m->getTime());
+    EXPECT_EQ(bag_m->getTopic(), baz_m->getTopic());
+    EXPECT_EQ(bag_m->getDataType(), baz_m->getDataType());
+    EXPECT_EQ(bag_m->getMD5Sum(), baz_m->getMD5Sum());
+    EXPECT_EQ(bag_m->getMessageDefinition(), baz_m->getMessageDefinition());
+
+    EXPECT_EQ(bag_message->header.seq, baz_message->header.seq);
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(TwoFileRegressionTestSuite, TwoFileRegressionTests,
+                        testing::Values(std::make_tuple("b0-2014-07-11-10-58-16.bag", "b0-2014-07-21-12-42-53.bag")));

--- a/src/io/thread_pool.cpp
+++ b/src/io/thread_pool.cpp
@@ -20,10 +20,11 @@ void process_async(std::mutex& sync, std::vector<std::function<void(void)>>& wor
   }
   else
   {
-    ROS_DEBUG_STREAM("Spawning " << max_threads << " threads to process " << work_items.size() << " work items");
+    const std::size_t num_threads = std::min(max_threads, work_items.size());
+    ROS_DEBUG_STREAM("Spawning " << num_threads << " threads to process " << work_items.size() << " work items");
 
     std::vector<std::future<void>> thread_pool;
-    for (size_t i = 0; i < max_threads; ++i)
+    for (size_t i = 0; i < num_threads; ++i)
     {
       thread_pool.emplace_back(std::async(std::launch::async, [&sync, &work_items]() {
         while (true)

--- a/src/message_instance.cpp
+++ b/src/message_instance.cpp
@@ -55,35 +55,14 @@ void MessageInstance::getOffsetAndSize(uint64_t& record_offset, uint32_t& record
 {
   assert(m_bag->chunk_indices_parsed_);
 
-  auto found_chunk = std::find_if(m_bag->chunk_exts_.begin(), m_bag->chunk_exts_.end(),
-                                  [this](const rosbaz::bag_parsing::ChunkExt& chunk_ext) {
-                                    return chunk_ext.chunk_info.pos == m_index_entry->chunk_pos;
-                                  });
+  const auto& found_chunk = m_bag->chunk_exts_lookup_.at(m_index_entry->chunk_pos);
+  const auto& found_size = found_chunk->message_records.at(m_index_entry->offset);
 
-  if (found_chunk == m_bag->chunk_exts_.end())
-  {
-    std::stringstream msg;
-    msg << "Requested chunk at pos=" << m_index_entry->chunk_pos << " could not be found in index.";
-    throw rosbaz::InvalidBagIndexException(msg.str());
-  }
-
-  auto found_size = std::find_if(
-      found_chunk->message_records.begin(), found_chunk->message_records.end(),
-      [this](const rosbaz::bag_parsing::MessageRecordInfo& info) { return info.offset == m_index_entry->offset; });
-
-  if (found_size == found_chunk->message_records.end())
-  {
-    std::stringstream msg;
-    msg << "Requested message record with offset=" << m_index_entry->offset << " and chunk pos "
-        << m_index_entry->chunk_pos << " could not be found in index.";
-    throw rosbaz::InvalidBagIndexException(msg.str());
-  }
-
-  ROS_DEBUG_STREAM("chunk_pos: " << m_index_entry->chunk_pos << " offset: " << found_size->offset
-                                 << " size: " << found_size->data_size);
+  ROS_DEBUG_STREAM("chunk_pos: " << m_index_entry->chunk_pos << " offset: " << found_size.offset
+                                 << " size: " << found_size.data_size);
 
   record_offset = found_chunk->data_offset + m_index_entry->offset;
-  record_size = found_size->data_size;
+  record_size = found_size.data_size;
 }
 
 std::vector<rosbaz::io::byte> MessageInstance::read_subset(uint32_t offset, uint32_t size) const

--- a/src/message_instance.cpp
+++ b/src/message_instance.cpp
@@ -55,12 +55,12 @@ void MessageInstance::getOffsetAndSize(uint64_t& record_offset, uint32_t& record
 {
   assert(m_bag->chunk_indices_parsed_);
 
-  auto found_chunk = std::find_if(m_bag->chunks_.begin(), m_bag->chunks_.end(),
+  auto found_chunk = std::find_if(m_bag->chunk_exts_.begin(), m_bag->chunk_exts_.end(),
                                   [this](const rosbaz::bag_parsing::ChunkExt& chunk_ext) {
                                     return chunk_ext.chunk_info.pos == m_index_entry->chunk_pos;
                                   });
 
-  if (found_chunk == m_bag->chunks_.end())
+  if (found_chunk == m_bag->chunk_exts_.end())
   {
     std::stringstream msg;
     msg << "Requested chunk at pos=" << m_index_entry->chunk_pos << " could not be found in index.";

--- a/src/query.cpp
+++ b/src/query.cpp
@@ -3,7 +3,25 @@
 namespace rosbaz
 {
 BagQuery::BagQuery(const Bag& _bag, const rosbag::Query& _query, uint32_t _bag_revision)
-  : bag(_bag), query(_query), bag_revision(_bag_revision)
+  : bag(&_bag), query(_query), bag_revision(_bag_revision)
 {
 }
+
+MessageRange::MessageRange(std::multiset<rosbag::IndexEntry>::const_iterator _begin,
+                           std::multiset<rosbag::IndexEntry>::const_iterator _end,
+                           const rosbag::ConnectionInfo& _connection_info, const BagQuery& _bag_query)
+  : begin(_begin), end(_end), connection_info(&_connection_info), bag_query(&_bag_query)
+{
+}
+
+bool ViewIterHelperCompare::operator()(ViewIterHelper const& a, ViewIterHelper const& b)
+{
+  return (a.iter)->time > (b.iter)->time;
+}
+
+ViewIterHelper::ViewIterHelper(std::multiset<rosbag::IndexEntry>::const_iterator _iter, const MessageRange& _range)
+  : iter(_iter), range(&_range)
+{
+}
+
 }  // namespace rosbaz


### PR DESCRIPTION
This PR aligns the implementation, naming, and header structure of rosbaz closer to rosbag to reduce friction in transition.

Moreover, a regression test for adding multiple bags to the same view is added.