### PR TITLE
Enable writing of bag files

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,26 @@ We tried to keep the API as close to the rosbag api as possible.
 #include <rosbaz/view.h>
 #include <std_msgs/Int32.h>
 
-auto url = rosbaz::AzBlobUrl::parse("https://contosoaccount.blob.core.windows.net/contosocontainer/my.bag?SAS_TOKEN");
-auto az_reader = std::make_shared<rosbaz::io::AzReader>(url);
+auto in_url = rosbaz::AzBlobUrl::parse("https://contosoaccount.blob.core.windows.net/contosocontainer/my.bag?SAS_TOKEN");
+auto az_reader = std::make_shared<rosbaz::io::AzReader>(in_url);
+auto in_bag = rosbaz::Bag::read(az_reader);
 
-auto bag = rosbaz::Bag::read(az_reader);
-
-for(const auto m : rosbaz::View(bag))
+for(const auto m : rosbaz::View(in_bag))
 {
   std_msgs::Int32::ConstPtr i = m.instantiate<std_msgs::Int32>();
   if (i != nullptr) {
     std::cout << i->data << std::endl;
   }
+}
+
+auto out_url = rosbaz::AzBlobUrl::parse("https://contosoaccount.blob.core.windows.net/contosocontainer/other.bag?SAS_TOKEN");
+
+auto az_writer = std::make_shared<rosbaz::io::AzWriter>(out_url);
+auto out_bag = rosbaz::Bag::read(az_writer);
+
+for(const auto m : rosbaz::View(in_bag))
+{
+  out_bag.write(m.getTopic(), m.getTime(), m);
 }
 ```
 
@@ -75,7 +84,6 @@ rosbaz info https://contosoaccount.blob.core.windows.net/contosocontainer/my.bag
 -   rosbag format 2.0
 -   no support for encryption
 -   no support for compressed chunks
--   only reading (not writing bags) is supported
 
 ## Build (Linux)
 

--- a/include/rosbaz/bag.h
+++ b/include/rosbaz/bag.h
@@ -233,6 +233,7 @@ private:
 
   bool chunk_indices_parsed_ = false;
 
+  // rosbag uses a map. Since for reading there are as many indices as chunk infos, it is safe to reserve once.
   std::unordered_map<uint32_t, std::multiset<rosbag::IndexEntry>> connection_indexes_;
 
   // for writing

--- a/include/rosbaz/bag.h
+++ b/include/rosbaz/bag.h
@@ -209,7 +209,7 @@ private:
 
   BagMode mode_;
 
-  std::unordered_map<uint32_t, std::unique_ptr<rosbag::ConnectionInfo>> connections_{};
+  std::unordered_map<uint32_t, std::shared_ptr<rosbag::ConnectionInfo>> connections_{};
 
   std::uint32_t bag_revision_{ 0 };
 

--- a/include/rosbaz/bag.h
+++ b/include/rosbaz/bag.h
@@ -396,7 +396,7 @@ void Bag::doWrite(const std::string& topic, ros::Time const& time, T const& msg,
 
     // Check if we want to stop this chunk
     uint32_t chunk_size = getChunkOffset();
-    // CONSOLE_BRIDGE_logDebug("  curr_chunk_size=%d (threshold=%d)", chunk_size, chunk_threshold_);
+    ROS_DEBUG("  curr_chunk_size=%d (threshold=%d)", chunk_size, chunk_threshold_);
     if (chunk_size > chunk_threshold_)
     {
       // Empty the outgoing chunk
@@ -426,15 +426,9 @@ void Bag::writeMessageDataRecord(uint32_t conn_id, ros::Time const& time, T cons
   // todo: serialize into the outgoing_chunk_buffer & remove record_buffer_
   ros::serialization::serialize(s, msg);
 
-  // // We do an extra seek here since writing our data record may
-  // // have indirectly moved our file-pointer if it was a
-  // // MessageInstance for our own bag
-  // seek(0, std::ios::end);
-  // file_size_ = file_.getOffset();
-
-  // CONSOLE_BRIDGE_logDebug("Writing MSG_DATA [%llu:%d]: conn=%d sec=%d nsec=%d data_len=%d",
-  //                         (unsigned long long)file_.getOffset(), getChunkOffset(), conn_id, time.sec, time.nsec,
-  //                         msg_ser_len);
+  ROS_DEBUG("Writing MSG_DATA [%llu:%d]: conn=%d sec=%d nsec=%d data_len=%d",
+            static_cast<unsigned long long>(current_block_->block_offset() + current_block_->size()), getChunkOffset(),
+            conn_id, time.sec, time.nsec, msg_ser_len);
 
   bag_writing::writeHeader(*current_block_, header);
   bag_writing::writeDataLength(*current_block_, msg_ser_len);

--- a/include/rosbaz/bag.h
+++ b/include/rosbaz/bag.h
@@ -182,7 +182,7 @@ private:
   void writeVersion(rosbaz::io::Block& block);
   void writeFileHeaderRecord(rosbaz::io::Block& block);
 
-  void writeConnectionRecord(rosbag::ConnectionInfo const* connection_info, const bool encrypt);
+  void writeConnectionRecord(rosbag::ConnectionInfo const* connection_info);
   void appendConnectionRecordToBuffer(Buffer& buf, rosbag::ConnectionInfo const* connection_info);
   template <class T>
   void writeMessageDataRecord(uint32_t conn_id, ros::Time const& time, T const& msg);
@@ -373,8 +373,7 @@ void Bag::doWrite(const std::string& topic, ros::Time const& time, T const& msg,
       }
       connections_[conn_id] = std::make_unique<rosbag::ConnectionInfo>(info);
       connection_info = connections_[conn_id].get();
-      // No need to encrypt connection records in chunks
-      writeConnectionRecord(connection_info, false);
+      writeConnectionRecord(connection_info);
     }
 
     // Add to topic indexes

--- a/include/rosbaz/bag.h
+++ b/include/rosbaz/bag.h
@@ -343,10 +343,6 @@ void Bag::doWrite(const std::string& topic, ros::Time const& time, T const& msg,
   }
 
   {
-    // // Seek to the end of the file (needed in case previous operation was a read)
-    // seek(0, std::ios::end);
-    // file_size_ = file_.getOffset();
-
     // Write the chunk header if we're starting a new chunk
     if (!current_block_)
     {

--- a/include/rosbaz/bag.h
+++ b/include/rosbaz/bag.h
@@ -183,7 +183,6 @@ private:
   void writeFileHeaderRecord(rosbaz::io::Block& block);
 
   void writeConnectionRecord(rosbag::ConnectionInfo const* connection_info);
-  void appendConnectionRecordToBuffer(Buffer& buf, rosbag::ConnectionInfo const* connection_info);
   template <class T>
   void writeMessageDataRecord(uint32_t conn_id, ros::Time const& time, T const& msg);
   void writeIndexRecords();
@@ -195,8 +194,6 @@ private:
 
   uint32_t writeHeader(ros::M_string const& fields, boost::optional<size_t> offset = boost::none);
   uint32_t writeDataLength(uint32_t data_len, boost::optional<size_t> offset = boost::none);
-  void appendHeaderToBuffer(Buffer& buf, ros::M_string const& fields);
-  void appendDataLengthToBuffer(Buffer& buf, uint32_t data_len);
 
   // This helper function actually does the write with an arbitrary serializable message
   template <class T>

--- a/include/rosbaz/bag.h
+++ b/include/rosbaz/bag.h
@@ -285,6 +285,11 @@ template <class T>
 void Bag::doWrite(const std::string& topic, ros::Time const& time, T const& msg,
                   boost::shared_ptr<ros::M_string> const& connection_header)
 {
+  if (mode_ != BagMode::Write)
+  {
+    throw InvalidModeException{ "Bag must be opened in write mode to support writing." };
+  }
+
   if (time < ros::TIME_MIN)
   {
     throw Exception("Tried to insert a message with time less than ros::TIME_MIN");

--- a/include/rosbaz/bag.h
+++ b/include/rosbaz/bag.h
@@ -7,16 +7,24 @@
 #include <vector>
 
 #include <rosbag/structures.h>
+#include <rosbag/constants.h>
+#include <ros/message_event.h>
+#include <ros/serialization.h>
 
 #include "rosbaz/bag_parsing/chunk_ext.h"
 #include "rosbaz/bag_parsing/header.h"
 #include "rosbaz/bag_parsing/record.h"
+#include "rosbaz/bag_writing/block_ext.h"
+#include "rosbaz/bag_writing/conversion.h"
+#include "rosbaz/io/util.h"
 
 namespace rosbaz
 {
 namespace io
 {
 class IReader;
+class IWriter;
+class Block;
 }  // namespace io
 
 namespace compression
@@ -55,6 +63,11 @@ public:
   /// Create a bag instance using the given reader.
   static Bag read(std::shared_ptr<rosbaz::io::IReader> reader, bool read_chunk_indices = true);
 
+  static Bag write(std::shared_ptr<rosbaz::io::IWriter> writer);
+
+  //! Close the bag file
+  void close();
+
   std::vector<const rosbag::ConnectionInfo*> getConnections() const;
 
   /// Get the filepath of the bag.
@@ -84,8 +97,60 @@ public:
   ros::Time getBeginTime() const;
   ros::Time getEndTime() const;
 
+  //! Write a message into the bag file
+  /*!
+   * \param topic The topic name
+   * \param event The message event to be added
+   *
+   * Can throw BagIOException
+   */
+  template <class T>
+  void write(const std::string& topic, ros::MessageEvent<T> const& event);
+
+  //! Write a message into the bag file
+  /*!
+   * \param topic The topic name
+   * \param time  Timestamp of the message
+   * \param msg   The message to be added
+   * \param connection_header  A connection header.
+   *
+   * Can throw BagIOException
+   */
+  template <class T>
+  void write(const std::string& topic, ros::Time const& time, T const& msg,
+             boost::shared_ptr<ros::M_string> connection_header = boost::shared_ptr<ros::M_string>());
+
+  //! Write a message into the bag file
+  /*!
+   * \param topic The topic name
+   * \param time  Timestamp of the message
+   * \param msg   The message to be added
+   * \param connection_header  A connection header.
+   *
+   * Can throw BagIOException
+   */
+  template <class T>
+  void write(const std::string& topic, ros::Time const& time, boost::shared_ptr<T const> const& msg,
+             boost::shared_ptr<ros::M_string> connection_header = boost::shared_ptr<ros::M_string>());
+
+  //! Write a message into the bag file
+  /*!
+   * \param topic The topic name
+   * \param time  Timestamp of the message
+   * \param msg   The message to be added
+   * \param connection_header  A connection header.
+   *
+   * Can throw BagIOException
+   */
+  template <class T>
+  void write(const std::string& topic, ros::Time const& time, boost::shared_ptr<T> const& msg,
+             boost::shared_ptr<ros::M_string> connection_header = boost::shared_ptr<ros::M_string>());
+
 private:
   explicit Bag(std::shared_ptr<rosbaz::io::IReader> reader);
+  explicit Bag(std::shared_ptr<rosbaz::io::IWriter> writer);
+
+  // Reading
 
   void parseFileHeaderRecord(const rosbaz::bag_parsing::Record& file_header_record);
 
@@ -110,13 +175,52 @@ private:
   /// The implementation may read data for the present chunks simultaneously.
   void parseChunkIndices(rosbaz::io::IReader& reader);
 
-  mutable std::shared_ptr<rosbaz::io::IReader> reader_{};
+  // Writing
 
-  // rosbag uses a map<uint32_t, ConnectionInfo*>. Since only parseFileTail can modify connections_
-  // it is safe to store the ConnectionInfo in the map. Only expansion would invalidate the addresses.
-  std::unordered_map<uint32_t, rosbag::ConnectionInfo> connections_{};
+  uint32_t getChunkOffset() const;
+
+  void writeVersion(rosbaz::io::Block& block);
+  void writeFileHeaderRecord(rosbaz::io::Block& block);
+
+  void writeConnectionRecord(rosbag::ConnectionInfo const* connection_info, const bool encrypt);
+  void appendConnectionRecordToBuffer(Buffer& buf, rosbag::ConnectionInfo const* connection_info);
+  template <class T>
+  void writeMessageDataRecord(uint32_t conn_id, ros::Time const& time, T const& msg);
+  void writeIndexRecords();
+  void writeConnectionRecords();
+  void writeChunkInfoRecords();
+  void startWritingChunk(ros::Time time);
+  void writeChunkHeader(CompressionType compression, uint32_t compressed_size, uint32_t uncompressed_size);
+  void stopWritingChunk();
+
+  uint32_t writeHeader(ros::M_string const& fields, boost::optional<size_t> offset = boost::none);
+  uint32_t writeDataLength(uint32_t data_len, boost::optional<size_t> offset = boost::none);
+  void appendHeaderToBuffer(Buffer& buf, ros::M_string const& fields);
+  void appendDataLengthToBuffer(Buffer& buf, uint32_t data_len);
+
+  // This helper function actually does the write with an arbitrary serializable message
+  template <class T>
+  void doWrite(const std::string& topic, ros::Time const& time, T const& msg,
+               boost::shared_ptr<ros::M_string> const& connection_header);
+
+  void closeWrite();
+
+  void startWriting();
+  void stopWriting();
+
+  // shared for reading and writing
+
+  BagMode mode_;
+
+  std::unordered_map<uint32_t, std::unique_ptr<rosbag::ConnectionInfo>> connections_{};
 
   std::uint32_t bag_revision_{ 0 };
+
+  // plain rosbag chunk infos
+  std::vector<rosbag::ChunkInfo> chunks_{};
+
+  // for reading
+  mutable std::shared_ptr<rosbaz::io::IReader> reader_{};
 
   std::uint32_t chunk_count_{ 0 };
   std::uint32_t connection_count_{ 0 };
@@ -126,15 +230,229 @@ private:
 
   std::uint64_t file_size_{ 0 };
 
-  // plain rosbag chunk infos
-  std::vector<rosbag::ChunkInfo> chunks_{};
   // extended chunk info needed for rosbaz
   std::vector<rosbaz::bag_parsing::ChunkExt> chunk_exts_{};
   std::unordered_map<uint64_t, const rosbaz::bag_parsing::ChunkExt*> chunk_exts_lookup_{};
 
   bool chunk_indices_parsed_ = false;
 
-  // rosbag uses a map. Since there are as many indices as chunk infos, it is safe to reserve once.
-  std::unordered_map<uint32_t, std::multiset<rosbag::IndexEntry>> connection_indexes_{};
+  std::unordered_map<uint32_t, std::multiset<rosbag::IndexEntry>> connection_indexes_;
+
+  // for writing
+  mutable std::shared_ptr<rosbaz::io::IWriter> writer_{};
+
+  std::map<std::string, uint32_t> topic_connection_ids_;
+  std::map<ros::M_string, uint32_t> header_connection_ids_;
+
+  uint32_t chunk_threshold_{ 768 * 1024 };  // 768KB chunks
+
+  rosbag::ChunkInfo curr_chunk_info_;
+  size_t curr_chunk_data_pos_{};
+  std::map<uint32_t, std::multiset<rosbag::IndexEntry>> curr_chunk_connection_indexes_;
+
+  std::shared_ptr<rosbaz::io::Block> header_block_;
+  std::shared_ptr<rosbaz::io::Block> current_block_;
+  Buffer record_buffer_;
 };
+
+// Templated method definitions
+
+template <class T>
+void Bag::write(const std::string& topic, ros::MessageEvent<T> const& event)
+{
+  doWrite(topic, event.getReceiptTime(), *event.getMessage(), event.getConnectionHeaderPtr());
+}
+
+template <class T>
+void Bag::write(const std::string& topic, ros::Time const& time, T const& msg,
+                boost::shared_ptr<ros::M_string> connection_header)
+{
+  doWrite(topic, time, msg, connection_header);
+}
+
+template <class T>
+void Bag::write(const std::string& topic, ros::Time const& time, boost::shared_ptr<T const> const& msg,
+                boost::shared_ptr<ros::M_string> connection_header)
+{
+  doWrite(topic, time, *msg, connection_header);
+}
+
+template <class T>
+void Bag::write(const std::string& topic, ros::Time const& time, boost::shared_ptr<T> const& msg,
+                boost::shared_ptr<ros::M_string> connection_header)
+{
+  doWrite(topic, time, *msg, connection_header);
+}
+
+template <class T>
+void Bag::doWrite(const std::string& topic, ros::Time const& time, T const& msg,
+                  boost::shared_ptr<ros::M_string> const& connection_header)
+{
+  if (time < ros::TIME_MIN)
+  {
+    throw Exception("Tried to insert a message with time less than ros::TIME_MIN");
+  }
+
+  // Whenever we write we increment our revision
+  bag_revision_++;
+
+  // Get ID for connection header
+  rosbag::ConnectionInfo* connection_info = nullptr;
+  uint32_t conn_id = 0;
+  if (!connection_header)
+  {
+    // No connection header: we'll manufacture one, and store by topic
+
+    std::map<std::string, uint32_t>::iterator topic_connection_ids_iter = topic_connection_ids_.find(topic);
+    if (topic_connection_ids_iter == topic_connection_ids_.end())
+    {
+      conn_id = rosbaz::io::narrow<uint32_t>(connections_.size());
+      topic_connection_ids_[topic] = conn_id;
+    }
+    else
+    {
+      conn_id = topic_connection_ids_iter->second;
+      connection_info = connections_[conn_id].get();
+    }
+  }
+  else
+  {
+    // Store the connection info by the address of the connection header
+
+    // Add the topic name to the connection header, so that when we later search by
+    // connection header, we can disambiguate connections that differ only by topic name (i.e.,
+    // same callerid, same message type), #3755.  This modified connection header is only used
+    // for our bookkeeping, and will not appear in the resulting .bag.
+    ros::M_string connection_header_copy(*connection_header);
+    connection_header_copy["topic"] = topic;
+
+    std::map<ros::M_string, uint32_t>::iterator header_connection_ids_iter =
+        header_connection_ids_.find(connection_header_copy);
+    if (header_connection_ids_iter == header_connection_ids_.end())
+    {
+      conn_id = rosbaz::io::narrow<uint32_t>(connections_.size());
+      header_connection_ids_[connection_header_copy] = conn_id;
+    }
+    else
+    {
+      conn_id = header_connection_ids_iter->second;
+      connection_info = connections_[conn_id].get();
+    }
+  }
+
+  {
+    // // Seek to the end of the file (needed in case previous operation was a read)
+    // seek(0, std::ios::end);
+    // file_size_ = file_.getOffset();
+
+    // Write the chunk header if we're starting a new chunk
+    if (!current_block_)
+    {
+      startWritingChunk(time);
+    }
+
+    // Write connection info record, if necessary
+    if (connection_info == nullptr)
+    {
+      rosbag::ConnectionInfo info{};
+      info.id = conn_id;
+      info.topic = topic;
+      info.datatype = std::string(ros::message_traits::datatype(msg));
+      info.md5sum = std::string(ros::message_traits::md5sum(msg));
+      info.msg_def = std::string(ros::message_traits::definition(msg));
+      if (connection_header != NULL)
+      {
+        info.header = connection_header;
+      }
+      else
+      {
+        info.header = boost::make_shared<ros::M_string>();
+        (*info.header)["type"] = info.datatype;
+        (*info.header)["md5sum"] = info.md5sum;
+        (*info.header)["message_definition"] = info.msg_def;
+      }
+      connections_[conn_id] = std::make_unique<rosbag::ConnectionInfo>(info);
+      connection_info = connections_[conn_id].get();
+      // No need to encrypt connection records in chunks
+      writeConnectionRecord(connection_info, false);
+    }
+
+    // Add to topic indexes
+    rosbag::IndexEntry index_entry;
+    index_entry.time = time;
+    index_entry.chunk_pos = curr_chunk_info_.pos;
+    index_entry.offset = getChunkOffset();
+
+    std::multiset<rosbag::IndexEntry>& chunk_connection_index = curr_chunk_connection_indexes_[connection_info->id];
+    chunk_connection_index.insert(chunk_connection_index.end(), index_entry);
+
+    if (mode_ != BagMode::Write)
+    {
+      std::multiset<rosbag::IndexEntry>& connection_index = connection_indexes_[connection_info->id];
+      connection_index.insert(connection_index.end(), index_entry);
+    }
+
+    // Increment the connection count
+    curr_chunk_info_.connection_counts[connection_info->id]++;
+
+    // Write the message data
+    writeMessageDataRecord(conn_id, time, msg);
+
+    // Check if we want to stop this chunk
+    uint32_t chunk_size = getChunkOffset();
+    // CONSOLE_BRIDGE_logDebug("  curr_chunk_size=%d (threshold=%d)", chunk_size, chunk_threshold_);
+    if (chunk_size > chunk_threshold_)
+    {
+      // Empty the outgoing chunk
+      stopWritingChunk();
+
+      // We no longer have a valid curr_chunk_info
+      curr_chunk_info_.pos = -1;
+    }
+  }
+}
+
+template <class T>
+void Bag::writeMessageDataRecord(uint32_t conn_id, ros::Time const& time, T const& msg)
+{
+  ros::M_string header;
+  header[rosbag::OP_FIELD_NAME] = bag_writing::toHeaderString(&rosbag::OP_MSG_DATA);
+  header[rosbag::CONNECTION_FIELD_NAME] = bag_writing::toHeaderString(&conn_id);
+  header[rosbag::TIME_FIELD_NAME] = bag_writing::toHeaderString(&time);
+
+  // Assemble message in memory first, because we need to write its length
+  uint32_t msg_ser_len = ros::serialization::serializationLength(msg);
+
+  record_buffer_.resize(msg_ser_len);
+
+  ros::serialization::OStream s(record_buffer_.data(), msg_ser_len);
+
+  // todo: serialize into the outgoing_chunk_buffer & remove record_buffer_
+  ros::serialization::serialize(s, msg);
+
+  // // We do an extra seek here since writing our data record may
+  // // have indirectly moved our file-pointer if it was a
+  // // MessageInstance for our own bag
+  // seek(0, std::ios::end);
+  // file_size_ = file_.getOffset();
+
+  // CONSOLE_BRIDGE_logDebug("Writing MSG_DATA [%llu:%d]: conn=%d sec=%d nsec=%d data_len=%d",
+  //                         (unsigned long long)file_.getOffset(), getChunkOffset(), conn_id, time.sec, time.nsec,
+  //                         msg_ser_len);
+
+  bag_writing::writeHeader(*current_block_, header);
+  bag_writing::writeDataLength(*current_block_, msg_ser_len);
+  current_block_->write(record_buffer_.data(), msg_ser_len);
+
+  // Update the current chunk time range
+  if (time > curr_chunk_info_.end_time)
+  {
+    curr_chunk_info_.end_time = time;
+  }
+  else if (time < curr_chunk_info_.start_time)
+  {
+    curr_chunk_info_.start_time = time;
+  }
+}
+
 }  // namespace rosbaz

--- a/include/rosbaz/bag.h
+++ b/include/rosbaz/bag.h
@@ -65,7 +65,7 @@ public:
 
   static Bag write(std::shared_ptr<rosbaz::io::IWriter> writer);
 
-  //! Close the bag file
+  /// Close the bag file
   void close();
 
   std::vector<const rosbag::ConnectionInfo*> getConnections() const;
@@ -91,57 +91,56 @@ public:
   /// Get the threshold for creating new chunks.
   uint32_t getChunkThreshold() const;
 
+  /// Set the threshold for creating new chunks
+  void setChunkThreshold(uint32_t chunk_threshold);
+
   /// Get the compression method to use for writing chunks.
   CompressionType getCompression() const;
 
   ros::Time getBeginTime() const;
   ros::Time getEndTime() const;
 
-  //! Write a message into the bag file
-  /*!
-   * \param topic The topic name
-   * \param event The message event to be added
-   *
-   * Can throw BagIOException
-   */
+  /// Write a message into the bag file
+  ///
+  /// \param topic The topic name
+  /// \param event The message event to be added
+  ///
+  /// Can throw BagIOException
   template <class T>
   void write(const std::string& topic, ros::MessageEvent<T> const& event);
 
-  //! Write a message into the bag file
-  /*!
-   * \param topic The topic name
-   * \param time  Timestamp of the message
-   * \param msg   The message to be added
-   * \param connection_header  A connection header.
-   *
-   * Can throw BagIOException
-   */
+  /// Write a message into the bag file
+  /// 
+  /// \param topic The topic name
+  /// \param time  Timestamp of the message
+  /// \param msg   The message to be added
+  /// \param connection_header  A connection header.
+  /// 
+  /// Can throw BagIOException
   template <class T>
   void write(const std::string& topic, ros::Time const& time, T const& msg,
              boost::shared_ptr<ros::M_string> connection_header = boost::shared_ptr<ros::M_string>());
 
-  //! Write a message into the bag file
-  /*!
-   * \param topic The topic name
-   * \param time  Timestamp of the message
-   * \param msg   The message to be added
-   * \param connection_header  A connection header.
-   *
-   * Can throw BagIOException
-   */
+  /// Write a message into the bag file
+  /// 
+  /// \param topic The topic name
+  /// \param time  Timestamp of the message
+  /// \param msg   The message to be added
+  /// \param connection_header  A connection header.
+  /// 
+  /// Can throw BagIOException
   template <class T>
   void write(const std::string& topic, ros::Time const& time, boost::shared_ptr<T const> const& msg,
              boost::shared_ptr<ros::M_string> connection_header = boost::shared_ptr<ros::M_string>());
 
-  //! Write a message into the bag file
-  /*!
-   * \param topic The topic name
-   * \param time  Timestamp of the message
-   * \param msg   The message to be added
-   * \param connection_header  A connection header.
-   *
-   * Can throw BagIOException
-   */
+  /// Write a message into the bag file
+  /// 
+  /// \param topic The topic name
+  /// \param time  Timestamp of the message
+  /// \param msg   The message to be added
+  /// \param connection_header  A connection header.
+  /// 
+  /// Can throw BagIOException
   template <class T>
   void write(const std::string& topic, ros::Time const& time, boost::shared_ptr<T> const& msg,
              boost::shared_ptr<ros::M_string> connection_header = boost::shared_ptr<ros::M_string>());

--- a/include/rosbaz/bag_writing/block_ext.h
+++ b/include/rosbaz/bag_writing/block_ext.h
@@ -14,9 +14,5 @@ void writeHeader(rosbaz::io::Block& block, ros::M_string const& fields);
 
 void writeDataLength(rosbaz::io::Block& block, uint32_t data_len);
 
-void appendHeaderToBuffer(Buffer& buf, ros::M_string const& fields);
-
-void appendDataLengthToBuffer(Buffer& buf, uint32_t data_len);
-
 }  // namespace bag_writing
 }  // namespace rosbaz

--- a/include/rosbaz/bag_writing/block_ext.h
+++ b/include/rosbaz/bag_writing/block_ext.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "rosbaz/io/writer.h"
+#include "ros/common.h"
+
+#include <cstring>
+
+namespace rosbaz
+{
+namespace bag_writing
+{
+
+void writeHeader(rosbaz::io::Block& block, ros::M_string const& fields);
+
+void writeDataLength(rosbaz::io::Block& block, uint32_t data_len);
+
+void appendHeaderToBuffer(Buffer& buf, ros::M_string const& fields);
+
+void appendDataLengthToBuffer(Buffer& buf, uint32_t data_len);
+
+}  // namespace bag_writing
+}  // namespace rosbaz

--- a/include/rosbaz/bag_writing/conversion.h
+++ b/include/rosbaz/bag_writing/conversion.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "ros/time.h"
+#include <string>
+
+namespace rosbaz
+{
+namespace bag_writing
+{
+
+template <typename T>
+std::string toHeaderString(T const* field)
+{
+  return std::string(reinterpret_cast<const char*>(field), sizeof(T));
+}
+
+std::string toHeaderString(ros::Time const* field);
+
+}  // namespace bag_writing
+}  // namespace rosbaz

--- a/include/rosbaz/common.h
+++ b/include/rosbaz/common.h
@@ -2,6 +2,8 @@
 
 #include <rosbaz/internal/nonstd/span.hpp>
 
+#include <vector>
+
 namespace rosbaz
 {
 namespace io
@@ -10,4 +12,6 @@ using byte = uint8_t;
 }  // namespace io
 
 using DataSpan = nonstd::span<const rosbaz::io::byte>;
+
+using Buffer = std::vector<rosbaz::io::byte>;
 }  // namespace rosbaz

--- a/include/rosbaz/exceptions.h
+++ b/include/rosbaz/exceptions.h
@@ -84,4 +84,12 @@ public:
   }
 };
 
+class BlockStagedException : public Exception
+{
+public:
+  explicit BlockStagedException(std::string const& msg) : Exception(msg)
+  {
+  }
+};
+
 }  // namespace rosbaz

--- a/include/rosbaz/exceptions.h
+++ b/include/rosbaz/exceptions.h
@@ -68,4 +68,20 @@ public:
   }
 };
 
+class InvalidModeException : public Exception
+{
+public:
+  explicit InvalidModeException(std::string const& msg) : Exception(msg)
+  {
+  }
+};
+
+class UnstagedBlocksException : public Exception
+{
+public:
+  explicit UnstagedBlocksException(std::string const& msg) : Exception(msg)
+  {
+  }
+};
+
 }  // namespace rosbaz

--- a/include/rosbaz/io/az_reader.h
+++ b/include/rosbaz/io/az_reader.h
@@ -34,6 +34,8 @@ public:
   explicit AzReader(const AzBlobUrl& blob_url, const std::string& account_key, const std::string& token,
                     std::unique_ptr<ICacheStrategy> cache_strategy);
 
+  ~AzReader() override;
+
   size_t size() override;
 
   std::string filepath() override;

--- a/include/rosbaz/io/az_writer.h
+++ b/include/rosbaz/io/az_writer.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "rosbaz/blob_url.h"
+#include "rosbaz/io/writer.h"
+
+namespace Azure
+{
+namespace Storage
+{
+namespace Blobs
+{
+class BlockBlobClient;
+}
+}  // namespace Storage
+}  // namespace Azure
+
+namespace rosbaz
+{
+namespace io
+{
+class AzWriter;
+
+class AzBlock : public Block
+{
+public:
+  AzBlock(AzWriter& writer, size_t block_offset);
+
+  virtual ~AzBlock() = default;
+
+  void write(rosbaz::io::byte const* data, size_t n, boost::optional<size_t> offset = boost::none) override;
+
+  size_t size() const override;
+
+  void stage() override;
+
+  const std::string& id() const { return id_; }
+
+private:
+  AzWriter& writer_;
+
+  std::vector<rosbaz::io::byte> buffer_{};
+
+  std::string id_;
+};
+
+
+class AzWriter : public IWriter
+{
+public:
+  explicit AzWriter(const AzBlobUrl& blob_url, const std::string& account_key = "", const std::string& token = "");
+
+  ~AzWriter() override;
+
+  size_t size() override;
+
+  std::string filepath() override;
+
+  std::shared_ptr<Block> create_block() override;
+
+  std::shared_ptr<Block> replace_block(Block& original) override;
+
+  void commit_blocks() override;
+
+  bool has_unstaged_blocks() const override;
+
+  std::int32_t num_requests() const
+  {
+    return num_requests_;
+  }
+  std::int64_t num_bytes() const
+  {
+    return num_bytes_;
+  }
+
+private:
+  std::string container_{};
+  std::string blob_{};
+  std::shared_ptr<Azure::Storage::Blobs::BlockBlobClient> client_{};
+
+  std::int32_t num_requests_{ 0 };
+  std::int64_t num_bytes_{ 0 };
+
+  std::vector<std::shared_ptr<AzBlock>> blocks_{};
+
+  std::mutex mutex_{};
+
+  friend AzBlock;
+};
+
+}  // namespace io
+}  // namespace rosbaz

--- a/include/rosbaz/io/stream_writer.h
+++ b/include/rosbaz/io/stream_writer.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+#include <mutex>
+
+#include "rosbaz/io/writer.h"
+
+namespace rosbaz
+{
+namespace io
+{
+class StreamWriter;
+
+class StreamBlock : public Block
+{
+public:
+  StreamBlock(StreamWriter& writer);
+
+  virtual ~StreamBlock() = default;
+
+  void write(rosbaz::io::byte const* data, size_t n, boost::optional<size_t> offset = boost::none) override;
+
+  size_t size() const override;
+
+  void stage() override;
+
+private:
+  StreamWriter& writer_;
+  size_t size_{ 0 };
+};
+
+class StreamWriter : public IWriter
+{
+public:
+  explicit StreamWriter(std::ofstream target, const std::string& filepath = "");
+
+  ~StreamWriter();
+
+  size_t size() override;
+
+  std::string filepath() override;
+
+  static std::unique_ptr<IWriter> open(const std::string& file_path);
+
+  std::shared_ptr<Block> create_block() override;
+
+  std::shared_ptr<Block> replace_block(Block& original) override;
+
+  void commit_blocks() override;
+
+  bool has_unstaged_blocks() const override;
+
+private:
+  std::ofstream m_target;
+  std::string m_filepath;
+  std::mutex m_mutex{};
+
+  std::vector<std::shared_ptr<StreamBlock>> m_blocks{};
+
+  friend StreamBlock;
+};
+
+}  // namespace io
+}  // namespace rosbaz

--- a/include/rosbaz/io/writer.h
+++ b/include/rosbaz/io/writer.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "rosbaz/common.h"
+#include "rosbaz/io/io_helpers.h"
+#include <boost/optional.hpp>
+
+namespace rosbaz
+{
+namespace io
+{
+
+struct BlockId
+{
+};
+
+class Block
+{
+public:
+  Block(size_t block_offset);
+
+  virtual ~Block() = default;
+
+  virtual void write(const rosbaz::io::byte* data, size_t n, boost::optional<size_t> offset = boost::none) = 0;
+
+  void write(const std::string& s);
+
+  virtual void stage() = 0;
+
+  bool is_staged() const
+  {
+    return is_staged_;
+  }
+
+  // offset of the block within the bag
+  size_t block_offset() const
+  {
+    return block_offset_;
+  };
+
+  virtual size_t size() const = 0;
+
+protected:
+  bool is_staged_{ false };
+  size_t block_offset_{ 0 };
+};
+
+class IWriter
+{
+public:
+  virtual ~IWriter() = default;
+
+  virtual size_t size() = 0;
+
+  virtual std::string filepath() = 0;
+
+  virtual std::shared_ptr<Block> create_block() = 0;
+
+  virtual std::shared_ptr<Block> replace_block(Block& original) = 0;
+
+  virtual void commit_blocks() = 0;
+
+  virtual bool has_unstaged_blocks() const = 0;
+};
+
+}  // namespace io
+}  // namespace rosbaz

--- a/include/rosbaz/message_instance.h
+++ b/include/rosbaz/message_instance.h
@@ -180,7 +180,7 @@ boost::shared_ptr<T> MessageInstance::instantiate() const
 
   ros::serialization::PreDeserializeParams<T> predes_params;
   predes_params.message = ptr;
-  predes_params.connection_header = found_connection->second.header;
+  predes_params.connection_header = found_connection->second->header;
   ros::serialization::PreDeserialize<T>::notify(predes_params);
 
   ros::serialization::IStream s(const_cast<uint8_t*>(&(*record.data.begin())),

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>rosbaz</name>
-  <version>1.7.0</version>
+  <version>1.7.1</version>
   <description>Streaming rosbags from azure blob storage</description>
 
   <maintainer email="jan@bernloehrs.de">Jan Bernloehr</maintainer>

--- a/package.xml
+++ b/package.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>rosbaz</name>
-  <version>1.7.1</version>
-  <description>Streaming rosbags from azure blob storage</description>
+  <version>2.0.0</version>
+  <description>Streaming rosbags from and to azure blob storage</description>
 
   <maintainer email="jan@bernloehrs.de">Jan Bernloehr</maintainer>
 

--- a/regression_test/test_regression.cpp
+++ b/regression_test/test_regression.cpp
@@ -69,6 +69,8 @@ TEST_P(RegressionTests, equal_messages)
   rosbag::View bag_view{ bag, rosbag::TopicQuery(topic_name) };
 
   ASSERT_EQ(baz_view.size(), bag_view.size());
+  ASSERT_EQ(baz_view.getBeginTime(), bag_view.getBeginTime());
+  ASSERT_EQ(baz_view.getEndTime(), bag_view.getEndTime());
 
   for (size_t i = 0; i < baz_view.size(); ++i)
   {

--- a/regression_test/test_regression.cpp
+++ b/regression_test/test_regression.cpp
@@ -99,7 +99,10 @@ TEST_P(RegressionTests, instantiate_subset)
   auto baz_m = baz_view.begin();
   auto baz_message = baz_m->instantiate<sensor_msgs::Imu>();
 
-  const uint32_t kStdMsgHeaderSize = ros::serialization::serializationLength(std_msgs::Header{});
+  std_msgs::Header imu_header{};
+  imu_header.frame_id = "imu_link";
+
+  const uint32_t kStdMsgHeaderSize = ros::serialization::serializationLength(imu_header);
 
   auto header = baz_m->instantiate_subset<std_msgs::Header>(0, kStdMsgHeaderSize);
 

--- a/regression_test/test_write.cpp
+++ b/regression_test/test_write.cpp
@@ -38,7 +38,6 @@ public:
 
 TEST_P(WriteTests, equal_properties)
 {
-  ASSERT_EQ(baz->getFilePath(), bag->getFileName());
   ASSERT_EQ(baz->getSize(), bag->getSize());
   ASSERT_EQ(baz->getMode(), bag->getMode());
   ASSERT_EQ(baz->getMajorVersion(), bag->getMajorVersion());

--- a/regression_test/test_write.cpp
+++ b/regression_test/test_write.cpp
@@ -102,32 +102,4 @@ TEST_P(WriteTests, equal_messages)
   }
 }
 
-TEST_P(WriteTests, instantiate_subset)
-{
-  const std::string topic_name = "imu";
-
-  rosbaz::View baz_view{ *baz, rosbag::TopicQuery(topic_name) };
-
-  auto baz_m = baz_view.begin();
-  auto baz_message = baz_m->instantiate<sensor_msgs::Imu>();
-
-  const uint32_t kStdMsgHeaderSize = ros::serialization::serializationLength(std_msgs::Header{});
-
-  auto header = baz_m->instantiate_subset<std_msgs::Header>(0, kStdMsgHeaderSize);
-
-  ASSERT_EQ(baz_message->header.frame_id, header->frame_id);
-  ASSERT_EQ(baz_message->header.seq, header->seq);
-  ASSERT_EQ(baz_message->header.stamp, header->stamp);
-
-  const uint32_t kGeometryMsgsQuaternionSize = ros::serialization::serializationLength(geometry_msgs::Quaternion{});
-
-  auto quaternion =
-      baz_m->instantiate_subset<geometry_msgs::Quaternion>(kStdMsgHeaderSize, kGeometryMsgsQuaternionSize);
-
-  ASSERT_EQ(baz_message->orientation.x, quaternion->x);
-  ASSERT_EQ(baz_message->orientation.y, quaternion->y);
-  ASSERT_EQ(baz_message->orientation.z, quaternion->z);
-  ASSERT_EQ(baz_message->orientation.w, quaternion->w);
-}
-
 INSTANTIATE_TEST_CASE_P(WriteTestSuite, WriteTests, testing::Values("b0-2014-07-11-10-58-16-decompressed.bag"));

--- a/src/bag.cpp
+++ b/src/bag.cpp
@@ -467,7 +467,7 @@ BagMode Bag::getMode() const
 
 void Bag::writeVersion(rosbaz::io::Block& block)
 {
-  std::string version = std::string("#ROSBAG V") + rosbag::VERSION + std::string("\n");
+  const std::string version = std::string("#ROSBAG V") + rosbag::VERSION + std::string("\n");
 
   ROS_DEBUG("Writing VERSION [%llu]: %s",
             static_cast<unsigned long long>(current_block_->block_offset() + current_block_->size()), version.c_str());
@@ -523,8 +523,6 @@ void Bag::startWritingChunk(ros::Time time)
 
   // // Record where the data section of this chunk started
   curr_chunk_data_pos_ = current_block_->size();
-
-  // chunk_open_ = true;
 }
 
 void Bag::stopWritingChunk()
@@ -533,8 +531,8 @@ void Bag::stopWritingChunk()
   chunks_.push_back(curr_chunk_info_);
 
   // Get the uncompressed and compressed sizes
-  uint32_t uncompressed_size = getChunkOffset();
-  uint32_t compressed_size = uncompressed_size;
+  const uint32_t uncompressed_size = getChunkOffset();
+  const uint32_t compressed_size = uncompressed_size;
 
   // Write out the indexes and clear them
   writeIndexRecords();
@@ -564,15 +562,15 @@ void Bag::writeChunkHeader(CompressionType compression, uint32_t compressed_size
   chunk_header.compressed_size = compressed_size;
   chunk_header.uncompressed_size = uncompressed_size;
 
-  // ROS_DEBUG("Writing CHUNK [%llu]: compression=%s compressed=%d uncompressed=%d", (unsigned long
-  // long)file_.getOffset(),
-  //           chunk_header.compression.c_str(), chunk_header.compressed_size, chunk_header.uncompressed_size);
+  ROS_DEBUG("Writing CHUNK [%llu]: compression=%s compressed=%d uncompressed=%d",
+            static_cast<unsigned long long>(current_block_->block_offset() + current_block_->size()),
+            chunk_header.compression.c_str(), chunk_header.compressed_size, chunk_header.uncompressed_size);
 
   ros::M_string header;
   header[rosbag::OP_FIELD_NAME] = rosbaz::bag_writing::toHeaderString(&rosbag::OP_CHUNK);
   header[rosbag::COMPRESSION_FIELD_NAME] = chunk_header.compression;
   header[rosbag::SIZE_FIELD_NAME] = rosbaz::bag_writing::toHeaderString(&chunk_header.uncompressed_size);
-  uint32_t header_size = writeHeader(header, 0);
+  const uint32_t header_size = writeHeader(header, 0);
 
   writeDataLength(chunk_header.compressed_size, header_size);
 }
@@ -676,7 +674,8 @@ void Bag::closeWrite()
 
 void Bag::stopWriting()
 {
-  if (current_block_) {
+  if (current_block_)
+  {
     stopWritingChunk();
   }
 
@@ -723,8 +722,8 @@ void Bag::writeChunkInfoRecords()
     // Write the topic names and counts
     for (const auto& connection_count : chunk_info.connection_counts)
     {
-      uint32_t connection_id = connection_count.first;
-      uint32_t count = connection_count.second;
+      const uint32_t connection_id = connection_count.first;
+      const uint32_t count = connection_count.second;
 
       current_block_->write(reinterpret_cast<const rosbaz::io::byte*>(&connection_id), 4);
       current_block_->write(reinterpret_cast<const rosbaz::io::byte*>(&count), 4);

--- a/src/bag.cpp
+++ b/src/bag.cpp
@@ -526,7 +526,7 @@ void Bag::startWritingChunk(ros::Time time)
   // Write the chunk header, with a place-holder for the data sizes (we'll fill in when the chunk is finished)
   writeChunkHeader(getCompression(), 0, 0);
 
-  // // Record where the data section of this chunk started
+  // Record where the data section of this chunk started
   curr_chunk_data_pos_ = current_block_->size();
 }
 

--- a/src/bag.cpp
+++ b/src/bag.cpp
@@ -429,6 +429,11 @@ uint32_t Bag::getChunkThreshold() const
   return chunk_threshold_;
 }
 
+void Bag::setChunkThreshold(const uint32_t chunk_threshold)
+{
+  chunk_threshold_ = chunk_threshold;
+}
+
 CompressionType Bag::getCompression() const
 {
   return CompressionType::Uncompressed;

--- a/src/bag.cpp
+++ b/src/bag.cpp
@@ -180,7 +180,7 @@ void Bag::parseIndexSection(rosbaz::bag_parsing::ChunkExt& chunk_ext, rosbaz::Da
 
   // There may be multiple records in the given data span
   uint32_t offset = 0;
-  int idx = 0;
+  size_t idx = 0;
 
   std::vector<uint32_t> offsets;
 

--- a/src/bag.cpp
+++ b/src/bag.cpp
@@ -426,7 +426,7 @@ std::uint32_t Bag::getChunkCount() const
 
 uint32_t Bag::getChunkThreshold() const
 {
-  return 0;
+  return chunk_threshold_;
 }
 
 CompressionType Bag::getCompression() const

--- a/src/bag_writing/block_ext.cpp
+++ b/src/bag_writing/block_ext.cpp
@@ -1,0 +1,48 @@
+#include "rosbaz/bag_writing/block_ext.h"
+
+#include <ros/header.h>
+
+namespace rosbaz
+{
+namespace bag_writing
+{
+void writeHeader(rosbaz::io::Block& block, ros::M_string const& fields)
+{
+  boost::shared_array<uint8_t> header_buffer;
+  uint32_t header_len;
+  ros::Header::write(fields, header_buffer, header_len);
+  block.write(reinterpret_cast<const rosbaz::io::byte*>(&header_len), 4);
+  block.write(reinterpret_cast<const rosbaz::io::byte*>(header_buffer.get()), header_len);
+}
+
+void writeDataLength(rosbaz::io::Block& block, uint32_t data_len)
+{
+  block.write(reinterpret_cast<const rosbaz::io::byte*>(&data_len), 4);
+}
+
+void appendHeaderToBuffer(Buffer& buf, ros::M_string const& fields)
+{
+  boost::shared_array<uint8_t> header_buffer;
+  uint32_t header_len;
+  ros::Header::write(fields, header_buffer, header_len);
+
+  size_t offset = buf.size();
+
+  buf.resize(buf.size() + 4 + header_len);
+
+  memcpy(buf.data() + offset, &header_len, 4);
+  offset += 4;
+  memcpy(buf.data() + offset, header_buffer.get(), header_len);
+}
+
+void appendDataLengthToBuffer(Buffer& buf, uint32_t data_len)
+{
+  size_t offset = buf.size();
+
+  buf.resize(buf.size() + 4);
+
+  memcpy(buf.data() + offset, &data_len, 4);
+}
+
+}  // namespace bag_writing
+}  // namespace rosbaz

--- a/src/bag_writing/block_ext.cpp
+++ b/src/bag_writing/block_ext.cpp
@@ -20,29 +20,5 @@ void writeDataLength(rosbaz::io::Block& block, uint32_t data_len)
   block.write(reinterpret_cast<const rosbaz::io::byte*>(&data_len), 4);
 }
 
-void appendHeaderToBuffer(Buffer& buf, ros::M_string const& fields)
-{
-  boost::shared_array<uint8_t> header_buffer;
-  uint32_t header_len;
-  ros::Header::write(fields, header_buffer, header_len);
-
-  size_t offset = buf.size();
-
-  buf.resize(buf.size() + 4 + header_len);
-
-  memcpy(buf.data() + offset, &header_len, 4);
-  offset += 4;
-  memcpy(buf.data() + offset, header_buffer.get(), header_len);
-}
-
-void appendDataLengthToBuffer(Buffer& buf, uint32_t data_len)
-{
-  size_t offset = buf.size();
-
-  buf.resize(buf.size() + 4);
-
-  memcpy(buf.data() + offset, &data_len, 4);
-}
-
 }  // namespace bag_writing
 }  // namespace rosbaz

--- a/src/bag_writing/conversion.cpp
+++ b/src/bag_writing/conversion.cpp
@@ -1,0 +1,15 @@
+#include "rosbaz/bag_writing/conversion.h"
+
+namespace rosbaz
+{
+namespace bag_writing
+{
+
+std::string toHeaderString(ros::Time const* field)
+{
+  uint64_t packed_time = (((uint64_t)field->nsec) << 32) + field->sec;
+  return toHeaderString(&packed_time);
+}
+
+}  // namespace bag_writing
+}  // namespace rosbaz

--- a/src/bag_writing/conversion.cpp
+++ b/src/bag_writing/conversion.cpp
@@ -7,7 +7,7 @@ namespace bag_writing
 
 std::string toHeaderString(ros::Time const* field)
 {
-  uint64_t packed_time = (((uint64_t)field->nsec) << 32) + field->sec;
+  uint64_t packed_time = ((static_cast<uint64_t>(field->nsec)) << 32) + field->sec;
   return toHeaderString(&packed_time);
 }
 

--- a/src/io/az_bearer_token.h
+++ b/src/io/az_bearer_token.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <azure/core/credentials/credentials.hpp>
+
+#include <string>
+
+class BearerToken : public Azure::Core::Credentials::TokenCredential
+{
+public:
+  explicit BearerToken(const std::string& token) : m_token{ token }
+  {
+  }
+
+  Azure::Core::Credentials::AccessToken
+  GetToken(Azure::Core::Credentials::TokenRequestContext const& /* tokenRequestContext*/,
+           Azure::Core::Context const& /* context */) const override
+  {
+    Azure::Core::Credentials::AccessToken t;
+    t.Token = m_token;
+    return t;
+  }
+
+private:
+  std::string m_token;
+};

--- a/src/io/az_reader.cpp
+++ b/src/io/az_reader.cpp
@@ -74,6 +74,8 @@ AzReader::AzReader(const AzBlobUrl& blob_url, const std::string& account_key, co
   }
 }
 
+AzReader::~AzReader() = default;
+
 std::string AzReader::filepath()
 {
   return client_->GetUrl();

--- a/src/io/az_reader.cpp
+++ b/src/io/az_reader.cpp
@@ -1,5 +1,7 @@
 #include "rosbaz/io/az_reader.h"
 
+#include "az_bearer_token.h"
+
 #include <ros/console.h>
 
 #include <azure/core.hpp>
@@ -10,28 +12,6 @@
 #include "rosbaz/io/io_helpers.h"
 #include "rosbaz/io/small_element_cache.h"
 
-namespace
-{
-class BearerToken : public Azure::Core::Credentials::TokenCredential
-{
-public:
-  explicit BearerToken(const std::string& token) : m_token{ token }
-  {
-  }
-
-  Azure::Core::Credentials::AccessToken
-  GetToken(Azure::Core::Credentials::TokenRequestContext const& /* tokenRequestContext*/,
-           Azure::Core::Context const& /* context */) const override
-  {
-    Azure::Core::Credentials::AccessToken t;
-    t.Token = m_token;
-    return t;
-  }
-
-private:
-  std::string m_token;
-};
-}  // namespace
 
 namespace rosbaz
 {

--- a/src/io/az_writer.cpp
+++ b/src/io/az_writer.cpp
@@ -1,0 +1,153 @@
+#include "rosbaz/io/az_writer.h"
+
+#include "az_bearer_token.h"
+
+#include <azure/core.hpp>
+#include <azure/storage/blobs.hpp>
+
+#include "rosbaz/exceptions.h"
+#include "rosbaz/io/io_helpers.h"
+#include "rosbaz/io/util.h"
+
+#include <numeric>
+#include <iostream>
+
+namespace rosbaz
+{
+namespace io
+{
+AzBlock::AzBlock(AzWriter& writer, size_t block_offset) : Block{ block_offset }, writer_{ writer }
+{
+  const size_t id = writer.blocks_.size();
+  std::vector<uint8_t> id_as(sizeof(size_t));
+  std::copy_n(reinterpret_cast<const uint8_t*>(&id), sizeof(size_t), id_as.data());
+  id_ = Azure::Core::Convert::Base64Encode(id_as);
+}
+
+void AzBlock::write(rosbaz::io::byte const* data, size_t n, boost::optional<size_t> offset)
+{
+  size_t new_size = buffer_.size();
+
+  if (offset)
+  {
+    new_size = std::max(new_size, *offset + n);
+  }
+  else
+  {
+    new_size += n;
+  }
+
+  const size_t original_size = buffer_.size();
+
+  buffer_.resize(new_size);
+  rosbaz::io::byte* output = buffer_.data() + offset.value_or(original_size);
+
+  std::copy_n(data, n, output);
+}
+
+size_t AzBlock::size() const
+{
+  return buffer_.size();
+}
+
+void AzBlock::stage()
+{
+  Azure::Core::IO::MemoryBodyStream memory_stream{buffer_};
+  writer_.client_->StageBlock(id_, memory_stream);
+  is_staged_ = true;
+}
+
+AzWriter::AzWriter(const AzBlobUrl& blob_url, const std::string& account_key, const std::string& token)
+  : container_(blob_url.container_name), blob_(blob_url.blob_name)
+{
+  std::shared_ptr<Azure::Storage::Blobs::BlockBlobClient> blobClient;
+
+  if (!token.empty())
+  {
+    auto credential = std::make_shared<BearerToken>(token);
+    client_ = std::make_shared<Azure::Storage::Blobs::BlockBlobClient>(blob_url.to_string(), credential);
+  }
+  else if (!blob_url.sas_token.empty())
+  {
+    client_ = std::make_shared<Azure::Storage::Blobs::BlockBlobClient>(blob_url.to_string());
+  }
+  else if (!account_key.empty())
+  {
+    auto credential = std::make_shared<Azure::Storage::StorageSharedKeyCredential>(blob_url.account_name, account_key);
+    client_ = std::make_shared<Azure::Storage::Blobs::BlockBlobClient>(blob_url.to_string(), credential);
+  }
+  else
+  {
+    throw rosbaz::MissingCredentialsException("You must provide either a bearer token, a sas "
+                                              "token, or an account key.");
+  }
+}
+
+AzWriter::~AzWriter() = default;
+
+std::string AzWriter::filepath()
+{
+  return client_->GetUrl();
+}
+
+size_t AzWriter::size()
+{
+  std::lock_guard<std::mutex> lock_guard(mutex_);
+
+  return std::accumulate(blocks_.begin(), blocks_.end(), 0,
+                         [](size_t a, const auto& block) { return block->is_staged() ? a + block->size() : a; });
+}
+
+std::shared_ptr<Block> AzWriter::create_block()
+{
+  size_t position = size();
+  std::lock_guard<std::mutex> lock_guard(mutex_);
+  if (has_unstaged_blocks())
+  {
+    throw UnstagedBlocksException("Cannot create a new block while unstaged blocks present");
+  }
+
+  auto block = std::make_shared<AzBlock>(*this, position);
+  blocks_.push_back(block);
+  return block;
+}
+
+std::shared_ptr<Block> AzWriter::replace_block(Block& original)
+{
+  std::lock_guard<std::mutex> lock_guard(mutex_);
+  if (has_unstaged_blocks())
+  {
+    throw UnstagedBlocksException("Cannot create a new block while unstaged blocks present");
+  }
+
+  auto found =
+      std::find_if(blocks_.begin(), blocks_.end(), [&original](const auto& block) { return &*block == &original; });
+
+  if (found == blocks_.end())
+  {
+    throw Exception("Could not find given block in list");
+  }
+
+  *found = std::make_shared<AzBlock>(*this, original.block_offset());
+  return *found;
+}
+
+void AzWriter::commit_blocks()
+{
+  std::vector<std::string> block_ids;
+  for (const auto& block : blocks_)
+  {
+    block_ids.push_back(block->id());
+    std::cout << " " << block->id() << "\n";
+  }
+
+  client_->CommitBlockList(block_ids);
+}
+
+bool AzWriter::has_unstaged_blocks() const
+{
+  return std::any_of(blocks_.begin(), blocks_.end(), [](const auto& block) { return !block->is_staged(); });
+}
+
+}  // namespace io
+}  // namespace rosbaz

--- a/src/io/az_writer.cpp
+++ b/src/io/az_writer.cpp
@@ -26,6 +26,10 @@ AzBlock::AzBlock(AzWriter& writer, size_t block_offset) : Block{ block_offset },
 
 void AzBlock::write(rosbaz::io::byte const* data, size_t n, boost::optional<size_t> offset)
 {
+  if (is_staged())
+  {
+    throw BlockStagedException("Cannot write to staged block");
+  }
   size_t new_size = buffer_.size();
 
   if (offset)
@@ -52,7 +56,7 @@ size_t AzBlock::size() const
 
 void AzBlock::stage()
 {
-  Azure::Core::IO::MemoryBodyStream memory_stream{buffer_};
+  Azure::Core::IO::MemoryBodyStream memory_stream{ buffer_ };
   writer_.client_->StageBlock(id_, memory_stream);
   is_staged_ = true;
 }

--- a/src/io/stream_writer.cpp
+++ b/src/io/stream_writer.cpp
@@ -1,0 +1,111 @@
+#include "rosbaz/io/stream_writer.h"
+
+#include "rosbaz/exceptions.h"
+#include "rosbaz/io/io_helpers.h"
+#include "rosbaz/io/util.h"
+
+#include <numeric>
+
+namespace rosbaz
+{
+namespace io
+{
+StreamBlock::StreamBlock(StreamWriter& writer)
+  : Block{ rosbaz::io::narrow<size_t>(writer.m_target.tellp()) }, writer_{ writer }
+{
+}
+
+void StreamBlock::write(rosbaz::io::byte const* data, size_t n, boost::optional<size_t> offset)
+{
+  if (offset)
+  {
+    writer_.m_target.seekp(rosbaz::io::narrow<std::streampos>(block_offset_ + *offset));
+  }
+  writer_.m_target.write(reinterpret_cast<const char*>(data), n);
+
+  if (offset) {
+    size_ = std::max(size_, *offset + n);
+  } else {
+    size_ += n;
+  }
+}
+
+size_t StreamBlock::size() const
+{
+  return size_;
+}
+
+void StreamBlock::stage()
+{
+  is_staged_ = true;
+  writer_.m_target.seekp(rosbaz::io::narrow<std::streampos>(block_offset_ + size()));
+}
+
+std::unique_ptr<IWriter> StreamWriter::open(const std::string& file_path)
+{
+  std::ofstream ofs;
+  ofs.open(file_path, std::ios_base::out | std::ios_base::binary);
+
+  if (!ofs.good())
+  {
+    throw rosbaz::IoException("Error opening file: " + file_path);
+  }
+
+  return std::unique_ptr<rosbaz::io::IWriter>{ new rosbaz::io::StreamWriter{ std::move(ofs), file_path } };
+}
+
+StreamWriter::StreamWriter(std::ofstream target, const std::string& filepath)
+  : m_target(std::move(target)), m_filepath(filepath)
+{
+}
+
+size_t StreamWriter::size()
+{
+  std::lock_guard<std::mutex> lock_guard(m_mutex);
+
+  return std::accumulate(m_blocks.begin(), m_blocks.end(), 0,
+                         [](size_t a, const auto& block) { return block->is_staged() ? a + block->size() : a; });
+}
+
+std::string StreamWriter::filepath()
+{
+  return m_filepath;
+}
+
+std::shared_ptr<Block> StreamWriter::create_block()
+{
+  std::lock_guard<std::mutex> lock_guard(m_mutex);
+  if (has_unstaged_blocks())
+  {
+    throw UnstagedBlocksException("Cannot create a new block while unstaged blocks present");
+  }
+
+  auto block = std::make_shared<StreamBlock>(*this);
+  m_blocks.push_back(block);
+  return block;
+}
+
+std::shared_ptr<Block> StreamWriter::replace_block(Block& original)
+{
+  m_target.seekp(rosbaz::io::narrow<std::streampos>(original.block_offset()));
+  // TODO: remove id
+  return create_block();
+}
+
+void StreamWriter::commit_blocks()
+{
+  // noop
+}
+
+bool StreamWriter::has_unstaged_blocks() const
+{
+  return std::any_of(m_blocks.begin(), m_blocks.end(), [](const auto& block) { return !block->is_staged(); });
+}
+
+StreamWriter::~StreamWriter()
+{
+  m_target.close();
+}
+
+}  // namespace io
+}  // namespace rosbaz

--- a/src/io/stream_writer.cpp
+++ b/src/io/stream_writer.cpp
@@ -17,15 +17,22 @@ StreamBlock::StreamBlock(StreamWriter& writer)
 
 void StreamBlock::write(rosbaz::io::byte const* data, size_t n, boost::optional<size_t> offset)
 {
+  if (is_staged())
+  {
+    throw BlockStagedException("Cannot write to staged block");
+  }
   if (offset)
   {
     writer_.m_target.seekp(rosbaz::io::narrow<std::streampos>(block_offset_ + *offset));
   }
   writer_.m_target.write(reinterpret_cast<const char*>(data), n);
 
-  if (offset) {
+  if (offset)
+  {
     size_ = std::max(size_, *offset + n);
-  } else {
+  }
+  else
+  {
     size_ += n;
   }
 }

--- a/src/io/writer.cpp
+++ b/src/io/writer.cpp
@@ -1,0 +1,20 @@
+#include "rosbaz/io/writer.h"
+
+#include "rosbaz/io/io_helpers.h"
+
+namespace rosbaz
+{
+namespace io
+{
+
+Block::Block(size_t block_offset) : block_offset_{ block_offset }
+{
+}
+
+void Block::write(const std::string& s)
+{
+  write(reinterpret_cast<const rosbaz::io::byte*>(s.c_str()), s.length());
+}
+
+}  // namespace io
+}  // namespace rosbaz

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -147,7 +147,7 @@ void View::updateQueries(BagQuery& q)
   const Bag& bag = *q.bag;
   for (const auto& connection_info : bag.connections_)
   {
-    const rosbag::ConnectionInfo& connection = connection_info.second;
+    const rosbag::ConnectionInfo& connection = *connection_info.second;
 
     if (!q.query.getQuery()(&connection))
     {


### PR DESCRIPTION
Add the write capability to rosbaz. To this end, we first extend the bag api to accept an `IWriter` instance which follows a similar protocol as azure block blobs
- Bags are written sequentially in _blocks_.
- Only one block can be written at a time and when finished is _staged_.
- Once staged, the length of a block is immutable.
- A staged block can be re-written at a later point, though.
- Once all blocks are written, they are committed to the storage which materializes the bag.

The implementation follows the additional rule of one chunk per block, so whenever a chunk is written, it is staged.

For the file system backend, all writes are imminent. For the azure backend, all writes are to a buffer which is uploaded when staging.