### PR TITLE
Add rosbaz::io::Buffer

### DIFF
--- a/include/rosbaz/bag.h
+++ b/include/rosbaz/bag.h
@@ -16,6 +16,7 @@
 #include "rosbaz/bag_parsing/record.h"
 #include "rosbaz/bag_writing/block_ext.h"
 #include "rosbaz/bag_writing/conversion.h"
+#include "rosbaz/io/buffer.h"
 #include "rosbaz/io/util.h"
 
 namespace rosbaz
@@ -249,7 +250,7 @@ private:
 
   std::shared_ptr<rosbaz::io::Block> header_block_;
   std::shared_ptr<rosbaz::io::Block> current_block_;
-  Buffer record_buffer_;
+  rosbaz::io::Buffer record_buffer_;
 };
 
 // Templated method definitions

--- a/include/rosbaz/common.h
+++ b/include/rosbaz/common.h
@@ -13,5 +13,4 @@ using byte = uint8_t;
 
 using DataSpan = nonstd::span<const rosbaz::io::byte>;
 
-using Buffer = std::vector<rosbaz::io::byte>;
 }  // namespace rosbaz

--- a/include/rosbaz/io/az_writer.h
+++ b/include/rosbaz/io/az_writer.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "rosbaz/blob_url.h"
+#include "rosbaz/io/buffer.h"
 #include "rosbaz/io/writer.h"
 
 namespace Azure
@@ -43,7 +44,7 @@ public:
 private:
   AzWriter& writer_;
 
-  std::vector<rosbaz::io::byte> buffer_{};
+  rosbaz::io::Buffer buffer_{};
 
   std::string id_;
 };

--- a/include/rosbaz/io/buffer.h
+++ b/include/rosbaz/io/buffer.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "rosbaz/common.h"
+
+#include <cstdint>
+#include <cstddef>
+
+namespace rosbaz
+{
+namespace io
+{
+class Buffer
+{
+public:
+  using value_type = rosbaz::io::byte;
+  using size_type = size_t;
+  using pointer = rosbaz::io::byte*;
+  using const_pointer = const rosbaz::io::byte*;
+  using iterator = rosbaz::io::byte*;
+  using const_iterator = const rosbaz::io::byte*;
+
+  Buffer();
+  Buffer(size_type size);
+  Buffer(const_pointer begin, const_pointer end);
+
+  Buffer(const Buffer&);
+  Buffer& operator=(const Buffer&);
+
+  Buffer(Buffer&&);
+  Buffer& operator=(Buffer&&);
+
+  ~Buffer();
+
+  iterator begin();
+  const_iterator begin() const;
+
+  iterator end();
+  const_iterator end() const;
+
+  const rosbaz::io::byte* data() const;
+  rosbaz::io::byte* data();
+  size_type capacity() const;
+  size_type size() const;
+
+  void resize(size_type size);
+
+private:
+  void ensureCapacity(size_type capacity);
+
+private:
+  rosbaz::io::byte* buffer_{ nullptr };
+  size_type capacity_{ 0 };
+  size_type size_{ 0 };
+};
+
+}  // namespace io
+}  // namespace rosbaz

--- a/include/rosbaz/io/cache_entry.h
+++ b/include/rosbaz/io/cache_entry.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "rosbaz/common.h"
+#include "rosbaz/io/buffer.h"
 
 namespace rosbaz
 {
@@ -11,7 +12,7 @@ namespace io
 {
 struct CacheEntry
 {
-  std::vector<byte> data{};
+  rosbaz::io::Buffer data{};
   std::uint64_t offset{ 0 };
 };
 

--- a/include/rosbaz/io/cache_strategy.h
+++ b/include/rosbaz/io/cache_strategy.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "rosbaz/common.h"
+#include "rosbaz/io/buffer.h"
 
 namespace rosbaz
 {
@@ -20,7 +21,7 @@ public:
   virtual bool retrieve(rosbaz::io::byte* buffer, size_t offset, size_t count) = 0;
 
   /// Update the cache with the specified range of bytes.
-  virtual void update(std::vector<rosbaz::io::byte> data, size_t offset) = 0;
+  virtual void update(rosbaz::io::Buffer&& data, size_t offset) = 0;
 
   /// \return The number of bytes to load (returns at least \p count but the cache strategy can decide to request more
   /// data to load).

--- a/include/rosbaz/io/hybrid_element_cache.h
+++ b/include/rosbaz/io/hybrid_element_cache.h
@@ -24,7 +24,7 @@ public:
 
   bool retrieve(rosbaz::io::byte* buffer, size_t offset, size_t count) override;
 
-  void update(std::vector<rosbaz::io::byte> data, size_t offset) override;
+  void update(rosbaz::io::Buffer&& data, size_t offset) override;
 
   size_t cache_element_size(size_t count) override;
 

--- a/include/rosbaz/io/reader.h
+++ b/include/rosbaz/io/reader.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "rosbaz/common.h"
+#include "rosbaz/io/buffer.h"
 #include "rosbaz/io/io_helpers.h"
 
 namespace rosbaz
@@ -13,7 +14,7 @@ namespace io
 {
 struct HeaderBufferAndSize
 {
-  std::vector<rosbaz::io::byte> header_buffer;
+  rosbaz::io::Buffer header_buffer;
   uint32_t header_size;
   uint32_t data_size;
 
@@ -32,7 +33,7 @@ public:
 
   virtual std::string filepath() = 0;
 
-  std::vector<rosbaz::io::byte> read(size_t offset, size_t count);
+  rosbaz::io::Buffer read(size_t offset, size_t count);
 
   template <size_t N>
   std::array<rosbaz::io::byte, N> read(size_t offset)

--- a/include/rosbaz/io/small_element_cache.h
+++ b/include/rosbaz/io/small_element_cache.h
@@ -24,7 +24,7 @@ public:
 
   bool retrieve(rosbaz::io::byte* buffer, size_t offset, size_t count) override;
 
-  void update(std::vector<rosbaz::io::byte> data, size_t offset) override;
+  void update(rosbaz::io::Buffer&& data, size_t offset) override;
 
   size_t cache_element_size(size_t count) override;
 

--- a/include/rosbaz/message_instance.h
+++ b/include/rosbaz/message_instance.h
@@ -60,7 +60,7 @@ public:
   template <class T>
   boost::shared_ptr<T> instantiate_subset(uint32_t offset, uint32_t size) const;
 
-  std::vector<rosbaz::io::byte> read_subset(uint32_t offset, uint32_t size) const;
+  rosbaz::io::Buffer read_subset(uint32_t offset, uint32_t size) const;
 
   //! Write serialized message contents out to a stream
   template <typename Stream>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>rosbaz</name>
-  <version>2.0.0</version>
+  <version>2.1.0</version>
   <description>Streaming rosbags from and to azure blob storage</description>
 
   <maintainer email="jan@bernloehrs.de">Jan Bernloehr</maintainer>

--- a/src/io/az_reader.cpp
+++ b/src/io/az_reader.cpp
@@ -1,5 +1,7 @@
 #include "rosbaz/io/az_reader.h"
 
+#ifndef NO_AZ_BINDINGS
+
 #include "az_bearer_token.h"
 
 #include <ros/console.h>
@@ -102,8 +104,7 @@ void AzReader::read_fixed(rosbaz::io::byte* buffer, size_t offset, size_t count)
 
   const size_t download_size = cache_strategy_->cache_element_size(count);
 
-  std::vector<rosbaz::io::byte> download_buffer;
-  download_buffer.resize(download_size);
+  rosbaz::io::Buffer download_buffer{download_size};
 
   download(&(*download_buffer.begin()), offset, download_size);
   std::copy_n(download_buffer.begin(), count, buffer);
@@ -114,3 +115,4 @@ void AzReader::read_fixed(rosbaz::io::byte* buffer, size_t offset, size_t count)
 
 }  // namespace io
 }  // namespace rosbaz
+#endif

--- a/src/io/az_writer.cpp
+++ b/src/io/az_writer.cpp
@@ -1,5 +1,7 @@
 #include "rosbaz/io/az_writer.h"
 
+#ifndef NO_AZ_BINDINGS
+
 #include "az_bearer_token.h"
 
 #include <azure/core.hpp>
@@ -56,7 +58,7 @@ size_t AzBlock::size() const
 
 void AzBlock::stage()
 {
-  Azure::Core::IO::MemoryBodyStream memory_stream{ buffer_ };
+  Azure::Core::IO::MemoryBodyStream memory_stream{ buffer_.data(), buffer_.size() };
   writer_.client_->StageBlock(id_, memory_stream);
   is_staged_ = true;
 }
@@ -155,3 +157,4 @@ bool AzWriter::has_unstaged_blocks() const
 
 }  // namespace io
 }  // namespace rosbaz
+#endif

--- a/src/io/buffer.cpp
+++ b/src/io/buffer.cpp
@@ -1,0 +1,122 @@
+#include "rosbaz/io/buffer.h"
+
+#include <stdlib.h>
+
+namespace rosbaz
+{
+namespace io
+{
+Buffer::Buffer() = default;
+
+Buffer::Buffer(size_t size)
+{
+  resize(size);
+}
+
+Buffer::Buffer(const_pointer begin, const_pointer end)
+{
+  resize(end - begin);
+  std::copy(begin, end, buffer_);
+}
+
+Buffer::Buffer(const Buffer& other)
+{
+  resize(other.size());
+  std::copy(other.begin(), other.end(), buffer_);
+}
+
+Buffer& Buffer::operator=(const Buffer& other)
+{
+  resize(other.size());
+  std::copy(other.begin(), other.end(), buffer_);
+  return *this;
+}
+
+Buffer::Buffer(Buffer&& other) : buffer_{ other.buffer_ }, capacity_{ other.capacity_ }, size_{ other.size_ }
+{
+  other.buffer_ = nullptr;
+  other.capacity_ = 0;
+  other.size_ = 0;
+}
+
+Buffer& Buffer::operator=(Buffer&& other)
+{
+  buffer_ = other.buffer_;
+  capacity_ = other.capacity_;
+  size_ = other.size_;
+
+  other.buffer_ = nullptr;
+  other.capacity_ = 0;
+  other.size_ = 0;
+  return *this;
+}
+
+Buffer::~Buffer()
+{
+  if (buffer_)
+  {
+    free(buffer_);
+    buffer_ = nullptr;
+  }
+}
+
+Buffer::iterator Buffer::begin()
+{
+  return buffer_;
+}
+Buffer::const_iterator Buffer::begin() const
+{
+  return buffer_;
+}
+
+Buffer::iterator Buffer::end()
+{
+  return buffer_ + size_;
+}
+Buffer::const_iterator Buffer::end() const
+{
+  return buffer_ + size_;
+}
+
+const rosbaz::io::byte* Buffer::data() const
+{
+  return buffer_;
+}
+
+rosbaz::io::byte* Buffer::data()
+{
+  return buffer_;
+}
+size_t Buffer::capacity() const
+{
+  return capacity_;
+}
+size_t Buffer::size() const
+{
+  return size_;
+}
+
+void Buffer::resize(size_t size)
+{
+  size_ = size;
+  ensureCapacity(size);
+}
+
+void Buffer::ensureCapacity(size_t capacity)
+{
+  if (capacity <= capacity_)
+    return;
+
+  if (capacity_ == 0)
+    capacity_ = capacity;
+  else
+  {
+    while (capacity_ < capacity)
+      capacity_ *= 2;
+  }
+
+  buffer_ = reinterpret_cast<rosbaz::io::byte*>(realloc(buffer_, capacity_));
+}
+
+}  // namespace io
+}  // namespace rosbaz

--- a/src/io/hybrid_element_cache.cpp
+++ b/src/io/hybrid_element_cache.cpp
@@ -57,7 +57,7 @@ size_t HybridElementCacheStrategy::cache_element_size(size_t count)
   return std::max(max_small_element_size_, count);
 }
 
-void HybridElementCacheStrategy::update(std::vector<rosbaz::io::byte> data, size_t offset)
+void HybridElementCacheStrategy::update(rosbaz::io::Buffer&& data, size_t offset)
 {
   CacheEntry entry;
   entry.offset = offset;

--- a/src/io/reader.cpp
+++ b/src/io/reader.cpp
@@ -19,12 +19,10 @@ HeaderBufferAndSize IReader::read_header_buffer_and_size(size_t offset)
   return result;
 }
 
-std::vector<rosbaz::io::byte> IReader::read(size_t offset, size_t count)
+rosbaz::io::Buffer IReader::read(size_t offset, size_t count)
 {
-  std::vector<rosbaz::io::byte> buffer;
-  buffer.resize(count);
-  read_fixed(&(*buffer.begin()), offset, count);
-
+  rosbaz::io::Buffer buffer(count);
+  read_fixed(buffer.data(), offset, count);
   return buffer;
 }
 

--- a/src/io/small_element_cache.cpp
+++ b/src/io/small_element_cache.cpp
@@ -37,7 +37,7 @@ size_t SmallElementCacheStrategy::cache_element_size(size_t count)
   return std::max(max_element_size_, count);
 }
 
-void SmallElementCacheStrategy::update(std::vector<rosbaz::io::byte> data, size_t offset)
+void SmallElementCacheStrategy::update(rosbaz::io::Buffer&& data, size_t offset)
 {
   if (data.size() > max_element_size_)
   {

--- a/src/io/stream_reader.cpp
+++ b/src/io/stream_reader.cpp
@@ -18,7 +18,7 @@ std::unique_ptr<IReader> StreamReader::open(const std::string& file_path)
     throw rosbaz::IoException("Error opening file: " + file_path);
   }
 
-  return std::unique_ptr<rosbaz::io::IReader>{ new rosbaz::io::StreamReader{ std::move(ifs), file_path } };
+  return std::make_unique<rosbaz::io::StreamReader>(std::move(ifs), file_path);
 }
 
 StreamReader::StreamReader(rosbaz::io::RosStream source, const std::string& filepath)

--- a/src/message_instance.cpp
+++ b/src/message_instance.cpp
@@ -65,7 +65,7 @@ void MessageInstance::getOffsetAndSize(uint64_t& record_offset, uint32_t& record
   record_size = found_size.data_size;
 }
 
-std::vector<rosbaz::io::byte> MessageInstance::read_subset(uint32_t offset, uint32_t size) const
+rosbaz::io::Buffer MessageInstance::read_subset(uint32_t offset, uint32_t size) const
 {
   uint64_t record_offset;
   uint32_t record_size;


### PR DESCRIPTION
We used `vector<byte>` as a buffer which comes with an initialization penalty on `resize`. The `rosbag` implementation thus uses its own buffer which does not have the penalty. This PR adds a similar buffer with a slightly bigger API surface to enable all use-cases.