### PR TITLE
Simplify rosbaz API

### DIFF
--- a/include/rosbaz/bag.h
+++ b/include/rosbaz/bag.h
@@ -163,12 +163,11 @@ private:
   void parseIndexSection(rosbaz::bag_parsing::ChunkExt& chunk_ext, rosbaz::DataSpan chunk_index,
                          const uint64_t index_offset);
 
-  /// Reads the chunk header for the given \p chunk_info, extracts the position of and reads the index sections which
-  /// subsequently is analyzed by \p parseIndexSection.
+  /// Reads the chunk header for the given \p chunk_ext.chunk_info, extracts the position of and reads the index
+  /// sections which subsequently is analyzed by \p parseIndexSection.
   ///
   /// The implementation has to be thread safe since it may be invoked simultaneously for multiple chunks.
-  void parseChunkInfo(rosbaz::io::IReader& reader, const rosbag::ChunkInfo& chunk_info,
-                      rosbaz::bag_parsing::ChunkExt& chunk_ext, uint64_t next_chunk_pos);
+  void parseChunkInfo(rosbaz::io::IReader& reader, rosbaz::bag_parsing::ChunkExt& chunk_ext, uint64_t next_chunk_pos);
 
   /// Fills \p connection_indexes_ and \p chunk_exts_.
   ///

--- a/include/rosbaz/bag_parsing/chunk_ext.h
+++ b/include/rosbaz/bag_parsing/chunk_ext.h
@@ -42,9 +42,6 @@ struct ChunkExt
   std::uint64_t data_offset{ 0 };  // absolute
   std::uint32_t data_size{ 0 };
 
-  std::uint64_t index_offset{ 0 };  // absolute
-  std::uint32_t index_size{ 0 };
-
   std::unordered_map<uint64_t, MessageRecordInfo> message_records{};
 
   std::vector<IndexEntryExt> index_entries{};

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>rosbaz</name>
-  <version>2.2.0</version>
+  <version>2.2.1</version>
   <description>Streaming rosbags from and to azure blob storage</description>
 
   <maintainer email="jan@bernloehrs.de">Jan Bernloehr</maintainer>


### PR DESCRIPTION
Reduce number of arguments to `parseChunkInfo` and remove index data from `ChunkExt` because it is not used.