### PR TITLE
Update to latest sdk and refactor credentials

### DIFF
--- a/.github/workflows/catkin-build.yml
+++ b/.github/workflows/catkin-build.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: 'Azure/azure-sdk-for-cpp.git'
-        ref: 'azure-storage-blobs_12.2.0'
+        ref: 'azure-storage-blobs_12.8.0'
         path: 'azure-sdk-for-cpp'
 
     - name: 'build azure-sdk-for-cpp'

--- a/.github/workflows/catkin-build.yml
+++ b/.github/workflows/catkin-build.yml
@@ -39,6 +39,7 @@ jobs:
         cd azure-sdk-for-cpp
         mkdir build.release
         cd build.release
+        export AZURE_SDK_DISABLE_AUTO_VCPKG=ON
         cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DCMAKE_CXX_COMPILER=${{ matrix.compiler }}
         cmake --build . --parallel
         sudo cmake --install .

--- a/.github/workflows/catkin-build.yml
+++ b/.github/workflows/catkin-build.yml
@@ -22,8 +22,13 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: 'Azure/azure-sdk-for-cpp.git'
-        ref: 'azure-storage-blobs_12.8.0'
+        ref: 'azure-storage-blobs_12.9.0'
         path: 'azure-sdk-for-cpp'
+
+    - name: 'checkout rosbaz'
+      uses: actions/checkout@v2
+      with:
+        path: 'src'
 
     - name: 'build azure-sdk-for-cpp'
       env:
@@ -37,17 +42,13 @@ jobs:
         sudo apt-get update -qq
         sudo apt-get install -y libssl-dev libcurl4-openssl-dev cmake g++ uuid-dev cmake
         cd azure-sdk-for-cpp
+        git apply ../src/azure-sdk.patch
         mkdir build.release
         cd build.release
         export AZURE_SDK_DISABLE_AUTO_VCPKG=ON
-        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DCMAKE_CXX_COMPILER=${{ matrix.compiler }}
+        cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DDISABLE_AZURE_CORE_OPENTELEMETRY=ON -DCMAKE_CXX_COMPILER=${{ matrix.compiler }}
         cmake --build . --parallel
         sudo cmake --install .
-
-    - name: 'checkout rosbaz'
-      uses: actions/checkout@v2
-      with:
-        path: 'src'
 
     - uses: betwo/github-setup-catkin@master
       with:

--- a/.github/workflows/catkin-build.yml
+++ b/.github/workflows/catkin-build.yml
@@ -50,14 +50,12 @@ jobs:
         cmake --build . --parallel
         sudo cmake --install .
 
-    - uses: betwo/github-setup-catkin@master
+    - uses: ros-tooling/setup-ros@v0.7
       with:
-        ros-version: 'noetic'
-        build-tool: 'catkin_tools'
-        workspace: '$GITHUB_WORKSPACE'
+        required-ros-distributions: noetic
 
-    - name: 'build rosbaz'
-      run: catkin build -sc --no-status --no-notify -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} -DCMAKE_BUILD_TYPE=RelWithDebInfo
-
-    - name: 'test rosbaz'
-      run: catkin run_tests --no-status --no-notify --cmake-args -DREGRESSION_TESTS=ON && catkin_test_results
+    - uses: ros-tooling/action-ros-ci@v0.3
+      with:
+        package-name: rosbaz
+        target-ros1-distro: noetic
+        extra-cmake-args: -DREGRESSION_TESTS=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 option(REGRESSION_TESTS "Build and execute regression tests" OFF)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(ROSBAZ_CXX_FLAGS
   -Wall
   -Wextra
@@ -54,6 +54,7 @@ find_package(catkin REQUIRED
 )
 
 find_package(azure-storage-blobs-cpp CONFIG REQUIRED)
+find_package(azure-identity-cpp CONFIG REQUIRED)
 
 catkin_package(
   INCLUDE_DIRS include
@@ -82,7 +83,8 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 target_link_libraries(${PROJECT_NAME}
-  PRIVATE Azure::azure-storage-blobs
+  PUBLIC  Azure::azure-core
+  PRIVATE Azure::azure-storage-blobs Azure::azure-identity
 )
 
 file(GLOB _app_sources CONFIGURE_DEPENDS "app/*.cpp" "app/**/*.cpp")
@@ -90,7 +92,7 @@ file(GLOB _app_sources CONFIGURE_DEPENDS "app/*.cpp" "app/**/*.cpp")
 add_executable(${PROJECT_NAME}_app
   ${_app_sources}
 )
-target_link_libraries(${PROJECT_NAME}_app PRIVATE ${PROJECT_NAME})
+target_link_libraries(${PROJECT_NAME}_app PRIVATE ${PROJECT_NAME} Azure::azure-identity)
 set_target_properties(${PROJECT_NAME}_app PROPERTIES OUTPUT_NAME "rosbaz")
 
 set_target_properties(${PROJECT_NAME}_app

--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ out_bag.close();
 
 The following modes are supported
 
+-   Azure Cli Credential
+
+```bash
+az login
+
+rosbaz info https://contosoaccount.blob.core.windows.net/contosocontainer/my.bag
+```
+
 -   Bearer Token
 
 ```bash
@@ -104,14 +112,14 @@ sudo apt install -y libssl-dev libcurl4-openssl-dev cmake g++ uuid-dev libxml2-d
 sudo apt install software-properties-common
 
 curl -s https://apt.kitware.com/keys/kitware-archive-latest.asc | sudo apt-key add -
-sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
+sudo apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -sc) main"
 
 sudo apt install cmake
 ```
 
 3. Install azure-storage-blobs
 ```bash
-git clone --branch azure-storage-blobs_12.2.0 https://github.com/Azure/azure-sdk-for-cpp.git
+git clone --branch azure-storage-blobs_12.8.0 https://github.com/Azure/azure-sdk-for-cpp.git
 
 cd azure-sdk-for-cpp
 mkdir build.release

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ This package provides an implementation of a subset of the rosbag api and the `r
 Summarize contents of a bag
 
 ```bash
-rosbaz info https://contosoaccount.blob.core.windows.net/contosocontainer/my.bag?SAS_TOKEN
+rosbaz info https://contosoaccount.blob.core.windows.net/contosocontainer/my.bag
 ```
 
 Play back contents of a bag
 
 ```bash
-rosbaz play --paused https://contosoaccount.blob.core.windows.net/contosocontainer/my.bag?SAS_TOKEN
+rosbaz play --paused https://contosoaccount.blob.core.windows.net/contosocontainer/my.bag
 ```
 
 Note that only those topics with connected subscribers will actually be downloaded from azure.
@@ -119,7 +119,7 @@ sudo apt install cmake
 
 3. Install azure-storage-blobs
 ```bash
-git clone --branch azure-storage-blobs_12.8.0 https://github.com/Azure/azure-sdk-for-cpp.git
+git clone --branch azure-storage-blobs_12.9.0 https://github.com/Azure/azure-sdk-for-cpp.git
 
 cd azure-sdk-for-cpp
 mkdir build.release

--- a/azure-sdk.patch
+++ b/azure-sdk.patch
@@ -34,3 +34,16 @@ index 8773255f..c6106979 100644
  
  if (NOT DISABLE_AZURE_CORE_OPENTELEMETRY)
    add_subdirectory(azure-core-tracing-opentelemetry)
+diff --git a/sdk/core/azure-core/src/http/curl/curl.cpp b/sdk/core/azure-core/src/http/curl/curl.cpp
+index b8703eac..71c1d3ae 100644
+--- a/sdk/core/azure-core/src/http/curl/curl.cpp
++++ b/sdk/core/azure-core/src/http/curl/curl.cpp
+@@ -274,7 +274,7 @@ static void CleanupThread()
+   }
+ }
+ 
+-std::string PemEncodeFromBase64(std::string const& base64, std::string const& pemType)
++[[gnu::unused]] std::string PemEncodeFromBase64(std::string const& base64, std::string const& pemType)
+ {
+   std::stringstream rv;
+   rv << "-----BEGIN " << pemType << "-----" << std::endl;

--- a/azure-sdk.patch
+++ b/azure-sdk.patch
@@ -1,0 +1,36 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 285e9517..9737667e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -119,9 +119,9 @@ endif()
+ add_subdirectory(sdk/core)
+ add_subdirectory(sdk/attestation)
+ # AMQP doesn't work for UWP yet, and eventhubs depends on AMQP, so we cannot include eventhubs on UWP.
+-if (NOT BUILD_WINDOWS_UWP)
+-  add_subdirectory(sdk/eventhubs)
+-endif()
++# if (NOT BUILD_WINDOWS_UWP)
++#   add_subdirectory(sdk/eventhubs)
++# endif()
+ add_subdirectory(sdk/identity)
+ add_subdirectory(sdk/keyvault)
+ add_subdirectory(sdk/storage)
+diff --git a/sdk/core/CMakeLists.txt b/sdk/core/CMakeLists.txt
+index 8773255f..c6106979 100644
+--- a/sdk/core/CMakeLists.txt
++++ b/sdk/core/CMakeLists.txt
+@@ -10,10 +10,10 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+ 
+ add_subdirectory(azure-core)
+ 
+-if (NOT BUILD_WINDOWS_UWP)
+-  message(STATUS "Including AMQP library")
+-  add_subdirectory(azure-core-amqp)
+-endif()
++# if (NOT BUILD_WINDOWS_UWP)
++#   message(STATUS "Including AMQP library")
++#   add_subdirectory(azure-core-amqp)
++# endif()
+ 
+ if (NOT DISABLE_AZURE_CORE_OPENTELEMETRY)
+   add_subdirectory(azure-core-tracing-opentelemetry)

--- a/include/rosbaz/io/az_bearer_token.h
+++ b/include/rosbaz/io/az_bearer_token.h
@@ -4,22 +4,22 @@
 
 #include <string>
 
+namespace rosbaz
+{
+namespace io
+{
+
 class BearerToken : public Azure::Core::Credentials::TokenCredential
 {
 public:
-  explicit BearerToken(const std::string& token) : m_token{ token }
-  {
-  }
+  explicit BearerToken(const std::string& token);
 
   Azure::Core::Credentials::AccessToken
   GetToken(Azure::Core::Credentials::TokenRequestContext const& /* tokenRequestContext*/,
-           Azure::Core::Context const& /* context */) const override
-  {
-    Azure::Core::Credentials::AccessToken t;
-    t.Token = m_token;
-    return t;
-  }
+           Azure::Core::Context const& /* context */) const override;
 
 private:
   std::string m_token;
 };
+
+}}

--- a/include/rosbaz/io/az_reader.h
+++ b/include/rosbaz/io/az_reader.h
@@ -5,6 +5,9 @@
 #include "rosbaz/io/cache_strategy.h"
 #include "rosbaz/io/reader.h"
 
+#include <azure/core/credentials/credentials.hpp>
+#include <azure/storage/common/storage_credential.hpp>
+
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
@@ -33,12 +36,14 @@ namespace io
 class AzReader : public IReader
 {
 public:
-  explicit AzReader(const AzBlobUrl& blob_url, const std::string& account_key = "", const std::string& token = "");
+  explicit AzReader(const AzBlobUrl& blob_url, std::unique_ptr<ICacheStrategy> cache_strategy,
+                    std::shared_ptr<Azure::Core::Credentials::TokenCredential> credential = nullptr);
+  explicit AzReader(const AzBlobUrl& blob_url, std::unique_ptr<ICacheStrategy> cache_strategy,
+                    std::shared_ptr<Azure::Storage::StorageSharedKeyCredential> credential);
 
-  explicit AzReader(const AzBlobUrl& blob_url, std::unique_ptr<ICacheStrategy> cache_strategy);
-
-  explicit AzReader(const AzBlobUrl& blob_url, const std::string& account_key, const std::string& token,
-                    std::unique_ptr<ICacheStrategy> cache_strategy);
+  explicit AzReader(const AzBlobUrl& blob_url,
+                    std::shared_ptr<Azure::Core::Credentials::TokenCredential> credential = nullptr);
+  explicit AzReader(const AzBlobUrl& blob_url, std::shared_ptr<Azure::Storage::StorageSharedKeyCredential> credential);
 
   ~AzReader() override;
 

--- a/include/rosbaz/io/az_reader.h
+++ b/include/rosbaz/io/az_reader.h
@@ -5,9 +5,6 @@
 #include "rosbaz/io/cache_strategy.h"
 #include "rosbaz/io/reader.h"
 
-#include <azure/core/credentials/credentials.hpp>
-#include <azure/storage/common/storage_credential.hpp>
-
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
@@ -18,8 +15,16 @@
 
 namespace Azure
 {
+namespace Core
+{
+namespace Credentials
+{
+class TokenCredential;
+}
+}  // namespace Core
 namespace Storage
 {
+class StorageSharedKeyCredential;
 namespace Blobs
 {
 class BlobClient;

--- a/include/rosbaz/io/az_writer.h
+++ b/include/rosbaz/io/az_writer.h
@@ -10,13 +10,19 @@
 #include <mutex>
 #include <string>
 #include <vector>
-#include <azure/core/credentials/credentials.hpp>
-#include <azure/storage/common/storage_credential.hpp>
 
 namespace Azure
 {
+namespace Core
+{
+namespace Credentials
+{
+class TokenCredential;
+}
+}  // namespace Core
 namespace Storage
 {
+class StorageSharedKeyCredential;
 namespace Blobs
 {
 class BlockBlobClient;

--- a/include/rosbaz/io/az_writer.h
+++ b/include/rosbaz/io/az_writer.h
@@ -10,6 +10,8 @@
 #include <mutex>
 #include <string>
 #include <vector>
+#include <azure/core/credentials/credentials.hpp>
+#include <azure/storage/common/storage_credential.hpp>
 
 namespace Azure
 {
@@ -62,7 +64,9 @@ private:
 class AzWriter : public IWriter
 {
 public:
-  explicit AzWriter(const AzBlobUrl& blob_url, const std::string& account_key = "", const std::string& token = "");
+  explicit AzWriter(const AzBlobUrl& blob_url,
+                    std::shared_ptr<Azure::Core::Credentials::TokenCredential> credential = nullptr);
+  explicit AzWriter(const AzBlobUrl& blob_url, std::shared_ptr<Azure::Storage::StorageSharedKeyCredential> credential);
 
   ~AzWriter() override;
 

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>rosbaz</name>
-  <version>2.9.1</version>
+  <version>3.0.0</version>
   <description>Streaming rosbags from and to azure blob storage</description>
 
   <maintainer email="jan@bernloehrs.de">Jan Bernloehr</maintainer>

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,8 @@
   <depend>roscpp</depend>
   <depend>rosbag</depend>
 
+  <depend>azure-sdk</depend>
+
   <export>
   </export>
 </package>

--- a/regression_test/test_regression.cpp
+++ b/regression_test/test_regression.cpp
@@ -18,6 +18,8 @@ public:
   {
   }
 
+  virtual ~RegressionTests() noexcept {}
+
   rosbaz::Bag baz;
   rosbag::Bag bag;
 };
@@ -134,6 +136,8 @@ public:
     , bag1{ std::get<1>(GetParam()) }
   {
   }
+
+  virtual ~TwoFileRegressionTests() noexcept {}
 
   rosbaz::Bag baz0;
   rosbaz::Bag baz1;

--- a/src/io/az_bearer_token.cpp
+++ b/src/io/az_bearer_token.cpp
@@ -1,0 +1,21 @@
+#include "rosbaz/io/az_bearer_token.h"
+
+namespace rosbaz
+{
+namespace io
+{
+BearerToken::BearerToken(const std::string& token) : m_token{ token }
+{
+}
+
+Azure::Core::Credentials::AccessToken
+BearerToken::GetToken(Azure::Core::Credentials::TokenRequestContext const& /* tokenRequestContext*/,
+                      Azure::Core::Context const& /* context */) const
+{
+  Azure::Core::Credentials::AccessToken t;
+  t.Token = m_token;
+  return t;
+}
+
+}  // namespace io
+}  // namespace rosbaz

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -107,7 +107,7 @@ void View::iterator::increment()
 
   view_->update();
 
-  assert(!iters_.empty());
+  assert(!iters_.empty()); // increment called on end iterator
 
   // Note, updating may have blown away our message-ranges and
   // replaced them in general the ViewIterHelpers are no longer


### PR DESCRIPTION
- Update to azure-storage-blobs v12.9.0
- Switch to C++17
- Refactor AzReader and AzWriter to accept `Azure::Core::Credentials::TokenCredential` (for SAS, Bearer Token, Azure Cli, ...) or the legacy `Azure::Storage::StorageSharedKeyCredential` for the Account Key
- Switch ci to use `ros-tooling/action-ros-ci` and `ros-tooling/setup-ros`